### PR TITLE
Replace CustomEvent usage with UiEvent helpers

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,7 @@ import { TestProviders } from './tests/test-utils'
 import App from './App'
 import { validatePanelPercentage } from './utils/panel'
 import { vi } from 'vitest'
+import { UiEvent, emitUiEvent } from './common/uiEvents'
 
 // ---- Mock: react-split (layout only) ----
 vi.mock('react-split', () => ({
@@ -187,9 +188,7 @@ describe('App.tsx', () => {
       renderApp()
 
       // Trigger the spec start event
-      window.dispatchEvent(new CustomEvent('schaltwerk:start-agent-from-spec', {
-        detail: { name: 'test-spec' }
-      }))
+      emitUiEvent(UiEvent.StartAgentFromSpec, { name: 'test-spec' })
 
       // Wait for the event to be processed
       await waitFor(() => {

--- a/src/common/uiEvents.ts
+++ b/src/common/uiEvents.ts
@@ -2,15 +2,148 @@ export enum UiEvent {
   PermissionError = 'schaltwerk:permission-error',
   BackgroundStartMarked = 'schaltwerk:terminal-background-started',
   TerminalResizeRequest = 'schaltwerk:terminal-resize-request',
+  TerminalReset = 'schaltwerk:reset-terminals',
+  OpencodeSelectionResize = 'schaltwerk:opencode-selection-resize',
+  OpencodeSearchResize = 'schaltwerk:opencode-search-resize',
+  FocusTerminal = 'schaltwerk:focus-terminal',
+  TerminalReady = 'schaltwerk:terminal-ready',
+  SessionAction = 'schaltwerk:session-action',
+  StartAgentFromSpec = 'schaltwerk:start-agent-from-spec',
+  NewSessionPrefill = 'schaltwerk:new-session:prefill',
+  NewSessionPrefillPending = 'schaltwerk:new-session:prefill-pending',
+  NewSessionSetSpec = 'schaltwerk:new-session:set-spec',
+  NewSessionRequest = 'schaltwerk:new-session',
+  NewSpecRequest = 'schaltwerk:new-spec',
+  SessionCreated = 'schaltwerk:session-created',
+  SpecCreated = 'schaltwerk:spec-created',
+  RetryAgentStart = 'schaltwerk:retry-agent-start',
+  OpenNewProjectDialog = 'schaltwerk:open-new-project-dialog',
+  OpenDiffView = 'schaltwerk:open-diff-view',
+  OpenDiffFile = 'schaltwerk:open-diff-file',
+  TerminalFontUpdated = 'schaltwerk:terminal-font-updated',
+  FontSizeChanged = 'font-size-changed',
+  GlobalNewSessionShortcut = 'global-new-session-shortcut',
+  GlobalMarkReadyShortcut = 'global-mark-ready-shortcut',
+  NoProjectError = 'schaltwerk:no-project-error',
+  SpawnError = 'schaltwerk:spawn-error',
+  NotGitError = 'schaltwerk:not-git-error',
+  ModalsChanged = 'schaltwerk:modals-changed',
+  EnterSpecMode = 'schaltwerk:enter-spec-mode',
+}
+
+export interface TerminalResizeRequestDetail {
+  target: 'session' | 'orchestrator' | 'all'
+  sessionId?: string
+}
+
+export type TerminalResetDetail =
+  | { kind: 'orchestrator' }
+  | { kind: 'session'; sessionId: string }
+
+export type SelectionResizeDetail =
+  | { kind: 'session'; sessionId: string }
+  | { kind: 'orchestrator' }
+
+export interface FocusTerminalDetail {
+  terminalId?: string
+  focusType?: 'terminal' | 'claude'
+}
+
+export interface SessionActionDetail {
+  action: 'cancel' | 'cancel-immediate' | 'delete-spec'
+  sessionId: string
+  sessionName: string
+  sessionDisplayName?: string
+  branch?: string
+  hasUncommittedChanges?: boolean
+}
+
+export interface StartAgentFromSpecDetail {
+  name?: string
+}
+
+export interface NewSessionPrefillDetail {
+  name?: string
+  taskContent?: string
+  baseBranch?: string
+  lockName?: boolean
+  fromDraft?: boolean
+  originalSpecName?: string
+}
+
+export interface SessionCreatedDetail {
+  name: string
+}
+
+export interface SpecCreatedDetail {
+  name: string
+}
+
+export interface OpenDiffFileDetail {
+  filePath?: string
+}
+
+export interface TerminalFontUpdatedDetail {
+  fontFamily: string | null
+}
+
+export interface FontSizeChangedDetail {
+  terminalFontSize: number
+  uiFontSize: number
+}
+
+export interface TerminalErrorDetail {
+  error: string
+  terminalId: string
+}
+
+export interface ModalsChangedDetail {
+  openCount: number
+}
+
+export interface EnterSpecModeDetail {
+  sessionName: string
 }
 
 export type UiEventPayloads = {
   [UiEvent.PermissionError]: { error: string }
   [UiEvent.BackgroundStartMarked]: { terminalId: string }
-  [UiEvent.TerminalResizeRequest]: { target: 'session' | 'orchestrator' | 'all'; sessionId?: string }
+  [UiEvent.TerminalResizeRequest]: TerminalResizeRequestDetail
+  [UiEvent.TerminalReset]: TerminalResetDetail
+  [UiEvent.OpencodeSelectionResize]: SelectionResizeDetail
+  [UiEvent.OpencodeSearchResize]: SelectionResizeDetail
+  [UiEvent.FocusTerminal]: FocusTerminalDetail | undefined
+  [UiEvent.TerminalReady]: { terminalId: string }
+  [UiEvent.SessionAction]: SessionActionDetail
+  [UiEvent.StartAgentFromSpec]: StartAgentFromSpecDetail | undefined
+  [UiEvent.NewSessionPrefill]: NewSessionPrefillDetail | undefined
+  [UiEvent.NewSessionPrefillPending]: undefined
+  [UiEvent.NewSessionSetSpec]: undefined
+  [UiEvent.NewSessionRequest]: undefined
+  [UiEvent.NewSpecRequest]: undefined
+  [UiEvent.SessionCreated]: SessionCreatedDetail
+  [UiEvent.SpecCreated]: SpecCreatedDetail
+  [UiEvent.RetryAgentStart]: undefined
+  [UiEvent.OpenNewProjectDialog]: undefined
+  [UiEvent.OpenDiffView]: undefined
+  [UiEvent.OpenDiffFile]: OpenDiffFileDetail | undefined
+  [UiEvent.TerminalFontUpdated]: TerminalFontUpdatedDetail
+  [UiEvent.FontSizeChanged]: FontSizeChangedDetail
+  [UiEvent.GlobalNewSessionShortcut]: undefined
+  [UiEvent.GlobalMarkReadyShortcut]: undefined
+  [UiEvent.NoProjectError]: TerminalErrorDetail
+  [UiEvent.SpawnError]: TerminalErrorDetail
+  [UiEvent.NotGitError]: TerminalErrorDetail
+  [UiEvent.ModalsChanged]: ModalsChangedDetail
+  [UiEvent.EnterSpecMode]: EnterSpecModeDetail
 }
 
-export function emitUiEvent<T extends UiEvent>(event: T, detail: UiEventPayloads[T]): void {
+type UiEventArgs<T extends UiEvent> = undefined extends UiEventPayloads[T]
+  ? [UiEventPayloads[T]?]
+  : [UiEventPayloads[T]]
+
+export function emitUiEvent<T extends UiEvent>(event: T, ...args: UiEventArgs<T>): void {
+  const detail = (args.length > 0 ? args[0] : undefined) as UiEventPayloads[T]
   window.dispatchEvent(new CustomEvent(String(event), { detail }))
 }
 

--- a/src/components/diff/DiffFileList.tsx
+++ b/src/components/diff/DiffFileList.tsx
@@ -8,7 +8,7 @@ import { VscFile, VscDiffAdded, VscDiffModified, VscDiffRemoved, VscFileBinary, 
 import clsx from 'clsx'
 import { isBinaryFileByExtension } from '../../utils/binaryDetection'
 import { logger } from '../../utils/logger'
-import { TERMINAL_RESET_EVENT } from '../../types/terminalEvents'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 import { AnimatedText } from '../common/AnimatedText'
 import { ConfirmResetDialog } from '../common/ConfirmResetDialog'
 import { ConfirmDiscardDialog } from '../common/ConfirmDiscardDialog'
@@ -301,9 +301,7 @@ export function DiffFileList({ onFileSelect, sessionNameOverride, isCommander }:
     try {
       await invoke(TauriCommands.SchaltwerkCoreResetSessionWorktree, { sessionName })
       await loadChangedFilesRef.current()
-      window.dispatchEvent(new CustomEvent(TERMINAL_RESET_EVENT, {
-        detail: { kind: 'session', sessionId: sessionName },
-      }))
+      emitUiEvent(UiEvent.TerminalReset, { kind: 'session', sessionId: sessionName })
     } catch (e) {
       logger.error('Failed to reset session from header:', e)
     } finally {

--- a/src/components/diff/DiffSessionActions.tsx
+++ b/src/components/diff/DiffSessionActions.tsx
@@ -7,7 +7,7 @@ import { ConfirmResetDialog } from '../common/ConfirmResetDialog'
 import { ConfirmDiscardDialog } from '../common/ConfirmDiscardDialog'
 import { MarkReadyConfirmation } from '../modals/MarkReadyConfirmation'
 import { logger } from '../../utils/logger'
-import { TERMINAL_RESET_EVENT } from '../../types/terminalEvents'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 type DiffSessionActionsRenderProps = {
   headerActions: ReactNode
@@ -74,9 +74,7 @@ export function DiffSessionActions({
       setIsResetting(true)
       await invoke(TauriCommands.SchaltwerkCoreResetSessionWorktree, { sessionName })
       await onLoadChangedFiles()
-      window.dispatchEvent(new CustomEvent(TERMINAL_RESET_EVENT, {
-        detail: { kind: 'session', sessionId: sessionName },
-      }))
+      emitUiEvent(UiEvent.TerminalReset, { kind: 'session', sessionId: sessionName })
       onClose()
     } catch (error) {
       logger.error('Failed to reset session worktree:', error)

--- a/src/components/diff/UnifiedDiffModal.reset.test.tsx
+++ b/src/components/diff/UnifiedDiffModal.reset.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { UnifiedDiffModal } from './UnifiedDiffModal'
 import { TestProviders } from '../../tests/test-utils'
@@ -31,11 +31,6 @@ vi.mock('@tauri-apps/api/core', () => ({
 }))
 
 describe('UnifiedDiffModal reset button', () => {
-  beforeEach(() => {
-    // Set selection to a session context so the button renders
-    window.dispatchEvent(new CustomEvent('schaltwerk:set-selection', { detail: { kind: 'session', payload: 'demo' } }))
-  })
-
   it('renders reset button and triggers confirmation flow', async () => {
     render(
       <TestProviders>

--- a/src/components/modals/NewSessionModal.integration.test.tsx
+++ b/src/components/modals/NewSessionModal.integration.test.tsx
@@ -5,6 +5,7 @@ import { TestProviders } from '../../tests/test-utils'
 import { invoke } from '@tauri-apps/api/core'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import type { MockedFunction } from 'vitest'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 // Mock Tauri
 vi.mock('@tauri-apps/api/core', () => ({
@@ -318,15 +319,13 @@ describe('NewSessionModal Integration with SessionConfigurationPanel', () => {
         })
 
         // Simulate prefill event
-        window.dispatchEvent(new CustomEvent('schaltwerk:new-session:prefill', {
-            detail: {
-                name: 'prefilled_session',
-                taskContent: 'Test content',
-                baseBranch: 'feature/prefill',
-                lockName: false,
-                fromDraft: false
-            }
-        }))
+        emitUiEvent(UiEvent.NewSessionPrefill, {
+            name: 'prefilled_session',
+            taskContent: 'Test content',
+            baseBranch: 'feature/prefill',
+            lockName: false,
+            fromDraft: false
+        })
 
         await waitFor(() => {
             const nameInput = screen.getByDisplayValue('prefilled_session')

--- a/src/components/modals/NewSessionModal.test.tsx
+++ b/src/components/modals/NewSessionModal.test.tsx
@@ -3,6 +3,7 @@ import { TauriCommands } from '../../common/tauriCommands'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { NewSessionModal } from './NewSessionModal'
 import { ModalProvider } from '../../contexts/ModalContext'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 // Expose spies so tests can assert persistence/saves
 const mockGetSkipPermissions = vi.fn().mockResolvedValue(false)
@@ -112,7 +113,7 @@ describe('NewSessionModal', () => {
     expect(checkbox.checked).toBe(false)
     
     // First, dispatch prefill-pending event to prevent the useLayoutEffect from resetting state
-    window.dispatchEvent(new Event('schaltwerk:new-session:prefill-pending'))
+    emitUiEvent(UiEvent.NewSessionPrefillPending)
     
     // Small delay to ensure the prefill-pending state is set
     await new Promise(resolve => setTimeout(resolve, 10))
@@ -140,15 +141,13 @@ describe('NewSessionModal', () => {
     const specName = 'test-spec'
     
     await act(async () => {
-      window.dispatchEvent(new CustomEvent('schaltwerk:new-session:prefill', {
-        detail: {
-          name: specName,
-          taskContent: draftContent,
-          baseBranch: 'main',
-          lockName: true,
-          fromDraft: true,
-        }
-      }))
+      emitUiEvent(UiEvent.NewSessionPrefill, {
+        name: specName,
+        taskContent: draftContent,
+        baseBranch: 'main',
+        lockName: true,
+        fromDraft: true,
+      })
     })
     
     // Wait for the content to be prefilled
@@ -173,15 +172,13 @@ describe('NewSessionModal', () => {
     
     // Schedule the event to be dispatched slightly after the modal opens
     setTimeout(() => {
-      window.dispatchEvent(new CustomEvent('schaltwerk:new-session:prefill', {
-        detail: {
-          name: specName,
-          taskContent: draftContent,
-          baseBranch: 'main',
-          lockName: true,
-          fromDraft: true,
-        }
-      }))
+      emitUiEvent(UiEvent.NewSessionPrefill, {
+        name: specName,
+        taskContent: draftContent,
+        baseBranch: 'main',
+        lockName: true,
+        fromDraft: true,
+      })
     }, 50)
     
     // Now open the modal
@@ -339,13 +336,11 @@ describe('NewSessionModal', () => {
     // Dispatch the prefill event to simulate starting from a spec
     const draftContent = '# My Spec\n\nThis is the spec content.'
     await act(async () => {
-      window.dispatchEvent(new CustomEvent('schaltwerk:new-session:prefill', {
-        detail: {
-          name: 'test-spec',
-          taskContent: draftContent,
-          fromDraft: true, // This should make createAsDraft false (starting agent from spec)
-        }
-      }))
+      emitUiEvent(UiEvent.NewSessionPrefill, {
+        name: 'test-spec',
+        taskContent: draftContent,
+        fromDraft: true, // This should make createAsDraft false (starting agent from spec)
+      })
     })
     
     // Check that the label is "Initial prompt (optional)" when starting agent from spec

--- a/src/components/right-panel/RightPanelTabs.tsx
+++ b/src/components/right-panel/RightPanelTabs.tsx
@@ -11,6 +11,7 @@ import { SpecMetadataPanel as SpecMetadataPanel } from '../plans/SpecMetadataPan
 import Split from 'react-split'
 import { CopyBundleBar } from './CopyBundleBar'
 import { logger } from '../../utils/logger'
+import { emitUiEvent, UiEvent } from '../../common/uiEvents'
 
 interface RightPanelTabsProps {
   onFileSelect: (filePath: string) => void
@@ -36,10 +37,11 @@ export function RightPanelTabs({ onFileSelect, selectionOverride, isSpecOverride
 
       // Dispatch OpenCode resize event when internal right panel split drag ends
       try {
-        const detail = selection.kind === 'session'
-          ? { kind: 'session', sessionId: selection.payload }
-          : { kind: 'orchestrator' as const }
-        window.dispatchEvent(new CustomEvent('schaltwerk:opencode-selection-resize', { detail }))
+        if (selection.kind === 'session' && selection.payload) {
+          emitUiEvent(UiEvent.OpencodeSelectionResize, { kind: 'session', sessionId: selection.payload })
+        } else {
+          emitUiEvent(UiEvent.OpencodeSelectionResize, { kind: 'orchestrator' })
+        }
       } catch (e) {
         logger.warn('[RightPanelTabs] Failed to dispatch OpenCode resize event on internal split drag end', e)
       }

--- a/src/components/sidebar/Sidebar.test.tsx
+++ b/src/components/sidebar/Sidebar.test.tsx
@@ -3,6 +3,7 @@ import { TauriCommands } from '../../common/tauriCommands'
 import { render, screen, waitFor } from '@testing-library/react'
 import { Sidebar } from './Sidebar'
 import { TestProviders } from '../../tests/test-utils'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 // Mock dependencies
 vi.mock('@tauri-apps/api/core', () => ({
@@ -458,32 +459,27 @@ describe('Sidebar', () => {
     })
 
     it('should emit cancel events when requested', () => {
-      // Test the event emission logic directly - just test that events can be dispatched
       const mockEventListener = vi.fn()
-      
-      window.addEventListener('schaltwerk:session-action', mockEventListener)
 
-      // Simulate the event dispatch that happens in the component
-      const testEvent = new CustomEvent('schaltwerk:session-action', {
-        detail: {
-          action: 'cancel',
-          sessionId: 'test-session',
-          sessionName: 'test-session',
-          hasUncommittedChanges: true
-        }
-      })
-      
-      window.dispatchEvent(testEvent)
+      window.addEventListener(String(UiEvent.SessionAction), mockEventListener)
 
-      expect(mockEventListener).toHaveBeenCalled()
-      expect(testEvent.detail).toEqual({
+      emitUiEvent(UiEvent.SessionAction, {
         action: 'cancel',
         sessionId: 'test-session',
         sessionName: 'test-session',
         hasUncommittedChanges: true
       })
 
-      window.removeEventListener('schaltwerk:session-action', mockEventListener)
+      expect(mockEventListener).toHaveBeenCalled()
+      const eventArg = mockEventListener.mock.calls[0][0] as CustomEvent
+      expect(eventArg.detail).toEqual({
+        action: 'cancel',
+        sessionId: 'test-session',
+        sessionName: 'test-session',
+        hasUncommittedChanges: true
+      })
+
+      window.removeEventListener(String(UiEvent.SessionAction), mockEventListener)
     })
   })
 

--- a/src/components/terminal/Terminal.test.tsx
+++ b/src/components/terminal/Terminal.test.tsx
@@ -3,6 +3,7 @@ import { TauriCommands } from '../../common/tauriCommands'
 import { createRef } from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { MockTauriInvokeArgs } from '../../types/testing'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 // Type definitions for mocks
 interface MockTauriCore {
@@ -675,7 +676,7 @@ describe('Terminal component', () => {
     xterm.__setTrailingBlankLines(3)
 
     // Font-size change SHOULD tighten
-    window.dispatchEvent(new CustomEvent('font-size-changed', { detail: { terminalFontSize: 14, uiFontSize: 14 } }))
+    emitUiEvent(UiEvent.FontSizeChanged, { terminalFontSize: 14, uiFontSize: 14 })
     await advanceAndFlush(150)
     expect(xterm.scrollLines.mock.calls.some((c: unknown[]) => c[0] === -3)).toBe(true)
   })
@@ -1075,11 +1076,11 @@ describe('Terminal component', () => {
     xterm.rows = 48
     core.invoke.mockClear()
 
-    window.dispatchEvent(new CustomEvent('schaltwerk:opencode-search-resize', { detail: { kind: 'session', sessionId: 'other' } }))
+    emitUiEvent(UiEvent.OpencodeSearchResize, { kind: 'session', sessionId: 'other' })
     await advanceAndFlush(50)
     const baseline = core.invoke.mock.calls.filter(call => call[0] === TauriCommands.ResizeTerminal).length
 
-    window.dispatchEvent(new CustomEvent('schaltwerk:opencode-search-resize', { detail: { kind: 'session', sessionId: 'opencode' } }))
+    emitUiEvent(UiEvent.OpencodeSearchResize, { kind: 'session', sessionId: 'opencode' })
     await advanceAndFlush(100)
     const searchCalls = core.invoke.mock.calls.filter(call => call[0] === TauriCommands.ResizeTerminal)
     const lastArgs = searchCalls.at(-1)?.[1] as { cols: number; rows: number } | undefined
@@ -1090,7 +1091,7 @@ describe('Terminal component', () => {
     expect(searchCalls.length).toBeGreaterThan(baseline)
 
     core.invoke.mockClear()
-    window.dispatchEvent(new CustomEvent('schaltwerk:opencode-selection-resize', { detail: { kind: 'session', sessionId: 'opencode' } }))
+    emitUiEvent(UiEvent.OpencodeSelectionResize, { kind: 'session', sessionId: 'opencode' })
     await advanceAndFlush(100)
     const selectionCalls = core.invoke.mock.calls.filter(call => call[0] === TauriCommands.ResizeTerminal)
     expect(selectionCalls.length).toBeGreaterThan(0)
@@ -1187,7 +1188,7 @@ describe('Terminal component', () => {
     expect(String(xterm.options.fontFamily)).toContain('Victor Mono')
     expect(fontSpy).toHaveBeenCalledWith('Victor Mono')
 
-    window.dispatchEvent(new CustomEvent('schaltwerk:terminal-font-updated', { detail: { fontFamily: 'Cousine' } }))
+    emitUiEvent(UiEvent.TerminalFontUpdated, { fontFamily: 'Cousine' })
     await flushAll()
     await advanceAndFlush(50)
     await flushAll()

--- a/src/components/terminal/TerminalGrid.test.tsx
+++ b/src/components/terminal/TerminalGrid.test.tsx
@@ -3,7 +3,7 @@ import { TauriCommands } from '../../common/tauriCommands'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
 import { MockTauriInvokeArgs } from '../../types/testing'
-import { TERMINAL_RESET_EVENT } from '../../types/terminalEvents'
+import { UiEvent, emitUiEvent } from '../../common/uiEvents'
 
 // Type definitions for proper typing
 interface MockSplitProps {
@@ -538,11 +538,9 @@ describe('TerminalGrid', () => {
      }, { timeout: 3000 })
 
      // Dispatch reset event for unrelated session -> should be ignored (no remount)
-     act(() => {
-       window.dispatchEvent(new CustomEvent(TERMINAL_RESET_EVENT, {
-         detail: { kind: 'session', sessionId: 'unrelated-session' },
-       }))
-     })
+    act(() => {
+      emitUiEvent(UiEvent.TerminalReset, { kind: 'session', sessionId: 'unrelated-session' })
+    })
      await act(async () => {
        await Promise.resolve()
      })
@@ -552,11 +550,9 @@ describe('TerminalGrid', () => {
      expect(m.__getMountCount(bottomId)).toBe(initialBottomMounts)
 
      // Dispatch reset event for current session -> should trigger remount
-     act(() => {
-       window.dispatchEvent(new CustomEvent(TERMINAL_RESET_EVENT, {
-         detail: { kind: 'orchestrator' },
-       }))
-     })
+    act(() => {
+      emitUiEvent(UiEvent.TerminalReset, { kind: 'orchestrator' })
+    })
      await act(async () => {
        await Promise.resolve()
      })
@@ -573,11 +569,9 @@ describe('TerminalGrid', () => {
      expect(m.__getFocusSpy(bottomId)).toBeUndefined()
 
      // Dispatch another reset event after unmount -> should have no effect
-     act(() => {
-       window.dispatchEvent(new CustomEvent(TERMINAL_RESET_EVENT, {
-         detail: { kind: 'orchestrator' },
-       }))
-     })
+    act(() => {
+      emitUiEvent(UiEvent.TerminalReset, { kind: 'orchestrator' })
+    })
 
      // Mount counts should remain unchanged after unmount
      expect(m.__getMountCount(topId)).toBeGreaterThan(initialTopMounts)
@@ -1298,7 +1292,7 @@ describe('TerminalGrid', () => {
 
     // Dispatch a focus request targeting a specific terminal id
     act(() => {
-      window.dispatchEvent(new CustomEvent('schaltwerk:focus-terminal', { detail: { terminalId: bottomId, focusType: 'terminal' } }))
+      emitUiEvent(UiEvent.FocusTerminal, { terminalId: bottomId, focusType: 'terminal' })
     })
 
     // Deterministically wait for focusTerminal to be recorded
@@ -1316,7 +1310,7 @@ describe('TerminalGrid', () => {
     // Clear and simulate the terminal becoming ready; focus should be applied again deterministically
     act(() => {
       // Reset internal marker by issuing a bogus focus to null
-      window.dispatchEvent(new CustomEvent('schaltwerk:terminal-ready', { detail: { terminalId: bottomId } }))
+      emitUiEvent(UiEvent.TerminalReady, { terminalId: bottomId })
     })
 
     await waitFor(() => {

--- a/src/contexts/FontSizeContext.tsx
+++ b/src/contexts/FontSizeContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState, ReactNode } fro
 import { TauriCommands } from '../common/tauriCommands'
 import { invoke } from '@tauri-apps/api/core'
 import { logger } from '../utils/logger'
+import { emitUiEvent, UiEvent } from '../common/uiEvents'
 
 interface FontSizeContextType {
   terminalFontSize: number
@@ -71,9 +72,7 @@ export function FontSizeProvider({ children }: { children: ReactNode }) {
     document.documentElement.style.setProperty('--terminal-font-size', `${terminalFontSize}px`)
     document.documentElement.style.setProperty('--ui-font-size', `${uiFontSize}px`)
 
-    window.dispatchEvent(new CustomEvent('font-size-changed', {
-      detail: { terminalFontSize, uiFontSize }
-    }))
+    emitUiEvent(UiEvent.FontSizeChanged, { terminalFontSize, uiFontSize })
 
     const pending = { terminal: terminalFontSize, ui: uiFontSize }
 

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react'
 import { logger } from '../utils/logger'
+import { emitUiEvent, UiEvent } from '../common/uiEvents'
 
 interface ModalContextType {
     registerModal: (modalId: string) => void
@@ -38,9 +39,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         }
         // Emit a simple event others can use to detect modal state changes if needed
         try {
-            window.dispatchEvent(new CustomEvent('schaltwerk:modals-changed', {
-                detail: { openCount: openModals.size }
-            }))
+            emitUiEvent(UiEvent.ModalsChanged, { openCount: openModals.size })
         } catch (e) {
             logger.warn('[ModalContext] Failed to dispatch modals-changed event:', e)
         }

--- a/src/hooks/useModalPrefill.test.ts
+++ b/src/hooks/useModalPrefill.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useModalPrefill, processPrefillData, PrefillEventDetail, ModalPrefillHandlers } from './useModalPrefill'
+import { useModalPrefill, processPrefillData, ModalPrefillHandlers } from './useModalPrefill'
+import { UiEvent, emitUiEvent, NewSessionPrefillDetail } from '../common/uiEvents'
 
 describe('useModalPrefill', () => {
   describe('processPrefillData', () => {
@@ -19,7 +20,7 @@ describe('useModalPrefill', () => {
     })
 
     it('updates name and related state when name is provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         name: 'test-session',
         lockName: true,
       }
@@ -33,7 +34,7 @@ describe('useModalPrefill', () => {
     })
 
     it('updates agent content when provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         taskContent: '# Spec content\n\nDescription',
       }
 
@@ -43,7 +44,7 @@ describe('useModalPrefill', () => {
     })
 
     it('updates base branch when provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         baseBranch: 'main',
       }
 
@@ -53,7 +54,7 @@ describe('useModalPrefill', () => {
     })
 
     it('sets createAsDraft to false when fromDraft is true', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         fromDraft: true,
       }
 
@@ -63,7 +64,7 @@ describe('useModalPrefill', () => {
     })
 
     it('handles lockName being false', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         name: 'test-session',
         lockName: false,
       }
@@ -74,7 +75,7 @@ describe('useModalPrefill', () => {
     })
 
     it('does not update name when not provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         taskContent: 'Content only',
       }
 
@@ -87,7 +88,7 @@ describe('useModalPrefill', () => {
     })
 
     it('does not update agent content when not provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         name: 'test-session',
       }
 
@@ -97,7 +98,7 @@ describe('useModalPrefill', () => {
     })
 
     it('handles all fields being provided', () => {
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         name: 'full-session',
         taskContent: 'Full content',
         baseBranch: 'develop',
@@ -117,7 +118,7 @@ describe('useModalPrefill', () => {
     })
 
     it('handles empty detail object', () => {
-      const detail: PrefillEventDetail = {}
+      const detail: NewSessionPrefillDetail = {}
 
       processPrefillData(detail, handlers)
 
@@ -152,7 +153,7 @@ describe('useModalPrefill', () => {
       const { unmount } = renderHook(() => useModalPrefill(handlers))
 
       expect(addEventListenerSpy).toHaveBeenCalledWith(
-        'schaltwerk:new-session:prefill',
+        String(UiEvent.NewSessionPrefill),
         expect.any(Function)
       )
 
@@ -168,7 +169,7 @@ describe('useModalPrefill', () => {
       unmount()
 
       expect(removeEventListenerSpy).toHaveBeenCalledWith(
-        'schaltwerk:new-session:prefill',
+        String(UiEvent.NewSessionPrefill),
         expect.any(Function)
       )
 
@@ -178,7 +179,7 @@ describe('useModalPrefill', () => {
     it('handles prefill event when dispatched', () => {
       renderHook(() => useModalPrefill(handlers))
 
-      const detail: PrefillEventDetail = {
+      const detail: NewSessionPrefillDetail = {
         name: 'event-session',
         taskContent: 'Event content',
         baseBranch: 'main',
@@ -186,8 +187,7 @@ describe('useModalPrefill', () => {
         fromDraft: true,
       }
 
-      const event = new CustomEvent('schaltwerk:new-session:prefill', { detail })
-      window.dispatchEvent(event)
+      emitUiEvent(UiEvent.NewSessionPrefill, detail)
 
       expect(handlers.setName).toHaveBeenCalledWith('event-session')
       expect(handlers.setTaskContent).toHaveBeenCalledWith('Event content')
@@ -201,8 +201,7 @@ describe('useModalPrefill', () => {
     it('handles event with empty detail', () => {
       renderHook(() => useModalPrefill(handlers))
 
-      const event = new CustomEvent('schaltwerk:new-session:prefill', { detail: {} })
-      window.dispatchEvent(event)
+      emitUiEvent(UiEvent.NewSessionPrefill, {})
 
       expect(handlers.setName).not.toHaveBeenCalled()
       expect(handlers.setTaskContent).not.toHaveBeenCalled()
@@ -213,8 +212,7 @@ describe('useModalPrefill', () => {
     it('handles event with no detail', () => {
       renderHook(() => useModalPrefill(handlers))
 
-      const event = new CustomEvent('schaltwerk:new-session:prefill')
-      window.dispatchEvent(event)
+      emitUiEvent(UiEvent.NewSessionPrefill)
 
       // Should not throw and should handle gracefully
       expect(handlers.setName).not.toHaveBeenCalled()

--- a/src/hooks/useModalPrefill.ts
+++ b/src/hooks/useModalPrefill.ts
@@ -1,12 +1,5 @@
 import { useEffect, Dispatch, SetStateAction } from 'react'
-
-export interface PrefillEventDetail {
-  name?: string
-  taskContent?: string
-  baseBranch?: string
-  lockName?: boolean
-  fromDraft?: boolean
-}
+import { UiEvent, NewSessionPrefillDetail, listenUiEvent } from '../common/uiEvents'
 
 export interface ModalPrefillHandlers {
   setName: Dispatch<SetStateAction<string>>
@@ -22,7 +15,7 @@ export interface ModalPrefillHandlers {
  * Processes the prefill event detail and updates the modal state
  */
 export function processPrefillData(
-  detail: PrefillEventDetail,
+  detail: NewSessionPrefillDetail,
   handlers: ModalPrefillHandlers
 ): void {
   const {
@@ -63,16 +56,10 @@ export function processPrefillData(
  */
 export function useModalPrefill(handlers: ModalPrefillHandlers) {
   useEffect(() => {
-    const prefillHandler = (event: CustomEvent<PrefillEventDetail>) => {
-      const detail = event.detail || {}
-      processPrefillData(detail, handlers)
-    }
+    const cleanup = listenUiEvent(UiEvent.NewSessionPrefill, detail => {
+      processPrefillData(detail ?? {}, handlers)
+    })
 
-    // Type assertion needed for custom event
-    window.addEventListener('schaltwerk:new-session:prefill', prefillHandler as EventListener)
-    
-    return () => {
-      window.removeEventListener('schaltwerk:new-session:prefill', prefillHandler as EventListener)
-    }
+    return cleanup
   }, [handlers])
 }

--- a/src/hooks/useSessionManagement.test.ts
+++ b/src/hooks/useSessionManagement.test.ts
@@ -4,19 +4,14 @@ import { renderHook, act } from '@testing-library/react'
 import { useSessionManagement } from './useSessionManagement'
 import { invoke } from '@tauri-apps/api/core'
 import * as TauriEvent from '@tauri-apps/api/event'
-import { TERMINAL_RESET_EVENT } from '../types/terminalEvents'
+import { UiEvent } from '../common/uiEvents'
 
 // Mock Tauri invoke
 vi.mock('@tauri-apps/api/core', () => ({
     invoke: vi.fn()
 }))
 
-// Mock window.dispatchEvent
-const mockDispatchEvent = vi.fn()
-Object.defineProperty(window, 'dispatchEvent', {
-    value: mockDispatchEvent,
-    writable: true
-})
+const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
 
 describe('useSessionManagement', () => {
     const mockTerminals = {
@@ -30,7 +25,12 @@ describe('useSessionManagement', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
+        dispatchSpy.mockClear()
         mockInvoke.mockResolvedValue(true)
+    })
+
+    afterAll(() => {
+        dispatchSpy.mockRestore()
     })
 
     describe('resetSession', () => {
@@ -52,9 +52,9 @@ describe('useSessionManagement', () => {
             expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreResetOrchestrator, {
                 terminalId: 'test-terminal-top'
             })
-            expect(mockDispatchEvent).toHaveBeenCalledWith(
+            expect(dispatchSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    type: TERMINAL_RESET_EVENT,
+                    type: String(UiEvent.TerminalReset),
                     detail: { kind: 'orchestrator' },
                 })
             )
@@ -95,9 +95,9 @@ describe('useSessionManagement', () => {
                 sessionName: 'test-session',
                 forceRestart: true
             })
-            expect(mockDispatchEvent).toHaveBeenCalledWith(
+            expect(dispatchSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    type: TERMINAL_RESET_EVENT,
+                    type: String(UiEvent.TerminalReset),
                     detail: { kind: 'session', sessionId: 'test-session' },
                 })
             )
@@ -326,9 +326,9 @@ describe('useSessionManagement', () => {
                 )
             })
 
-            expect(mockDispatchEvent).toHaveBeenCalledWith(
+            expect(dispatchSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    type: TERMINAL_RESET_EVENT,
+                    type: String(UiEvent.TerminalReset),
                     detail: { kind: 'orchestrator' },
                 })
             )
@@ -393,9 +393,9 @@ describe('useSessionManagement', () => {
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.TerminalExists, expect.any(Object))
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreStartClaude, expect.any(Object))
                 // Should still dispatch reset event and wait
-                expect(mockDispatchEvent).toHaveBeenCalledWith(
+                expect(dispatchSpy).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        type: TERMINAL_RESET_EVENT,
+                        type: String(UiEvent.TerminalReset),
                         detail: { kind: 'orchestrator' },
                     })
                 )
@@ -418,9 +418,9 @@ describe('useSessionManagement', () => {
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.TerminalExists, expect.any(Object))
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreStartClaude, expect.any(Object))
                 // Should still dispatch reset event and wait
-                expect(mockDispatchEvent).toHaveBeenCalledWith(
+                expect(dispatchSpy).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        type: TERMINAL_RESET_EVENT,
+                        type: String(UiEvent.TerminalReset),
                         detail: { kind: 'orchestrator' },
                     })
                 )
@@ -443,9 +443,9 @@ describe('useSessionManagement', () => {
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.TerminalExists, expect.any(Object))
                 expect(mockInvoke).not.toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreStartClaude, expect.any(Object))
                 // Should still dispatch reset event and wait
-                expect(mockDispatchEvent).toHaveBeenCalledWith(
+                expect(dispatchSpy).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        type: TERMINAL_RESET_EVENT,
+                        type: String(UiEvent.TerminalReset),
                         detail: { kind: 'orchestrator' },
                     })
                 )

--- a/src/hooks/useSessionManagement.ts
+++ b/src/hooks/useSessionManagement.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react'
 import { TauriCommands } from '../common/tauriCommands'
 import { invoke } from '@tauri-apps/api/core'
 import { SchaltEvent, listenEvent } from '../common/eventSystem'
-import { TerminalResetDetail, createTerminalResetEvent } from '../types/terminalEvents'
+import { UiEvent, emitUiEvent, TerminalResetDetail } from '../common/uiEvents'
 
 export interface SessionSelection {
     kind: 'orchestrator' | 'session'
@@ -76,7 +76,7 @@ export function useSessionManagement(): SessionManagementHookReturn {
     }, [])
 
     const notifyTerminalsReset = useCallback((detail: TerminalResetDetail): void => {
-        window.dispatchEvent(createTerminalResetEvent(detail))
+        emitUiEvent(UiEvent.TerminalReset, detail)
     }, [])
 
     const waitForAgentStarted = useCallback(async (terminalId: string): Promise<void> => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { TauriCommands } from '../common/tauriCommands'
 import { invoke } from '@tauri-apps/api/core'
 import { logger } from '../utils/logger'
+import { emitUiEvent, UiEvent } from '../common/uiEvents'
 import {
     KeyboardShortcutConfig,
     defaultShortcutConfig,
@@ -73,7 +74,7 @@ export const useSettings = () => {
         try {
             if (typeof window !== 'undefined') {
                 const font = terminalSettings.fontFamily || null
-                window.dispatchEvent(new CustomEvent('schaltwerk:terminal-font-updated', { detail: { fontFamily: font } }))
+                emitUiEvent(UiEvent.TerminalFontUpdated, { fontFamily: font })
             }
         } catch (e) {
             logger.warn('Failed to dispatch terminal font update event', e)

--- a/src/hooks/useSpecMode.test.ts
+++ b/src/hooks/useSpecMode.test.ts
@@ -3,6 +3,7 @@ import { useSpecMode, getSpecToSelect } from './useSpecMode'
 import { Selection } from '../contexts/SelectionContext'
 import { EnrichedSession } from '../types/session'
 import { FilterMode } from '../types/sessionFilters'
+import { UiEvent } from '../common/uiEvents'
 
 // Mock event system
 vi.mock('../common/eventSystem', () => ({
@@ -357,7 +358,7 @@ describe('useSpecMode', () => {
 
       expect(dispatchEventSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'schaltwerk:new-spec'
+          type: String(UiEvent.NewSpecRequest)
         })
       )
 

--- a/src/types/terminalEvents.ts
+++ b/src/types/terminalEvents.ts
@@ -1,8 +1,0 @@
-export const TERMINAL_RESET_EVENT = 'schaltwerk:reset-terminals'
-
-export type TerminalResetDetail =
-  | { kind: 'orchestrator' }
-  | { kind: 'session'; sessionId: string }
-
-export const createTerminalResetEvent = (detail: TerminalResetDetail): CustomEvent<TerminalResetDetail> =>
-  new CustomEvent(TERMINAL_RESET_EVENT, { detail })


### PR DESCRIPTION
## Summary
- replace manual terminal reset dispatches with `emitUiEvent` across diff views, session management, and terminal grid
- update selection and new session modal flows to use the shared `UiEvent` helpers, removing the legacy `types/terminalEvents` module
- refactor unit tests to emit UI events via `emitUiEvent`/`listenUiEvent` instead of constructing `CustomEvent` objects

## Testing
- npm run test *(fails: missing system dependency `gio-2.0` required by gio-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68d30887aa3c832abef60c31609b7b85