### PR TITLE
Rename MCP draft creation tool to spec terminology

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -407,6 +407,26 @@ pub async fn set_auto_commit_on_review(auto_commit: bool) -> Result<(), String> 
 }
 
 #[tauri::command]
+pub async fn get_keyboard_shortcuts() -> Result<HashMap<String, Vec<String>>, String> {
+    let settings_manager = SETTINGS_MANAGER
+        .get()
+        .ok_or_else(|| "Settings manager not initialized".to_string())?;
+
+    let manager = settings_manager.lock().await;
+    Ok(manager.get_keyboard_shortcuts())
+}
+
+#[tauri::command]
+pub async fn set_keyboard_shortcuts(shortcuts: HashMap<String, Vec<String>>) -> Result<(), String> {
+    let settings_manager = SETTINGS_MANAGER
+        .get()
+        .ok_or_else(|| "Settings manager not initialized".to_string())?;
+
+    let mut manager = settings_manager.lock().await;
+    manager.set_keyboard_shortcuts(shortcuts)
+}
+
+#[tauri::command]
 pub async fn get_project_action_buttons() -> Result<Vec<HeaderActionConfig>, String> {
     let project = PROJECT_MANAGER
         .get()

--- a/src-tauri/src/domains/agents/codex.rs
+++ b/src-tauri/src/domains/agents/codex.rs
@@ -221,6 +221,39 @@ pub fn find_codex_session_fast(path: &Path) -> Option<String> {
     }
 }
 
+fn sort_by_name_desc(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+    let mut items: Vec<PathBuf> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .collect();
+    items.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+    Ok(items)
+}
+
+fn sort_session_files_desc(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+    let mut files: Vec<PathBuf> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "jsonl"))
+        .collect();
+
+    files.sort_by(|a, b| {
+        let a_meta = a
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let b_meta = b
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+        match b_meta.cmp(&a_meta) {
+            std::cmp::Ordering::Equal => b.file_name().cmp(&a.file_name()),
+            other => other,
+        }
+    });
+
+    Ok(files)
+}
+
 // Efficiently finds the newest matching session for a given CWD by scanning
 // date-partitioned subdirectories from newest to oldest and exiting on first match.
 fn find_newest_session_for_cwd(
@@ -229,15 +262,6 @@ fn find_newest_session_for_cwd(
 ) -> Result<Option<PathBuf>, std::io::Error> {
     if !sessions_dir.exists() {
         return Ok(None);
-    }
-
-    // Helper to read and sort directory entries by name descending (YYYY/MM/DD)
-    fn sort_by_name_desc(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
-        let mut items: Vec<PathBuf> = fs::read_dir(dir)?
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .collect();
-        items.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
-        Ok(items)
     }
 
     // Iterate years → months → days (names are ISO-like so lexical desc works)
@@ -253,19 +277,7 @@ fn find_newest_session_for_cwd(
                 if !day.is_dir() {
                     continue;
                 }
-                // Within a day, sort files by modified time desc for accuracy
-                let mut files: Vec<PathBuf> = fs::read_dir(&day)?
-                    .filter_map(|e| e.ok().map(|e| e.path()))
-                    .filter(|p| p.extension().is_some_and(|ext| ext == "jsonl"))
-                    .collect();
-                files.sort_by_key(|p| {
-                    p.metadata()
-                        .and_then(|m| m.modified())
-                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
-                });
-                files.reverse();
-
-                for file in files {
+                for file in sort_session_files_desc(&day)? {
                     log::trace!("🔍 Fast scan check file: {}", file.display());
                     if session_matches_cwd(&file, target_cwd) {
                         log::debug!("✅ Newest matching session found: {}", file.display());
@@ -320,39 +332,28 @@ fn legacy_match_for_cwd(sessions_dir: &Path, target_cwd: &str) -> Option<MatchRe
 }
 
 fn find_newest_session(sessions_dir: &Path) -> Result<Option<PathBuf>, std::io::Error> {
-    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
-    fn scan(
-        dir: &Path,
-        newest: &mut Option<(std::time::SystemTime, PathBuf)>,
-    ) -> Result<(), std::io::Error> {
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                scan(&path, newest)?;
-            } else if path.extension().is_some_and(|ext| ext == "jsonl") {
-                if let Ok(meta) = path.metadata() {
-                    if let Ok(modified) = meta.modified() {
-                        match newest {
-                            Some((ts, _)) if &modified > ts => {
-                                *newest = Some((modified, path.clone()));
-                            }
-                            None => {
-                                *newest = Some((modified, path.clone()));
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
     if !sessions_dir.exists() {
         return Ok(None);
     }
-    scan(sessions_dir, &mut newest)?;
-    Ok(newest.map(|(_, p)| p))
+    for year in sort_by_name_desc(sessions_dir)? {
+        if !year.is_dir() {
+            continue;
+        }
+        for month in sort_by_name_desc(&year)? {
+            if !month.is_dir() {
+                continue;
+            }
+            for day in sort_by_name_desc(&month)? {
+                if !day.is_dir() {
+                    continue;
+                }
+                if let Some(first) = sort_session_files_desc(&day)?.into_iter().next() {
+                    return Ok(Some(first));
+                }
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn session_matches_cwd(session_file: &Path, target_cwd: &str) -> bool {
@@ -630,6 +631,7 @@ pub fn build_codex_command_with_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use filetime::{set_file_mtime, FileTime};
     use std::env;
     use std::fs;
     use std::io::Write;
@@ -1027,6 +1029,8 @@ mod tests {
 
     #[test]
     fn test_find_codex_session_fast_resume_when_old_match_exists() {
+        use filetime::{set_file_mtime, FileTime};
+
         let tmp = tempdir().unwrap();
         let day_old = tmp.path().join(".codex/sessions/2025/08/22");
         let day_new = tmp.path().join(".codex/sessions/2025/09/14");
@@ -1040,11 +1044,37 @@ mod tests {
         let new_other = day_new.join("rollout-2025-09-14T10-00-00-uuid.jsonl");
         write_jsonl_without_cwd(&new_other);
 
+        // Ensure deterministic ordering even on filesystems with coarse mod-time resolution.
+        set_file_mtime(&old_match, FileTime::from_unix_time(1, 0)).unwrap();
+        set_file_mtime(&new_other, FileTime::from_unix_time(2, 0)).unwrap();
+
         let newest_match =
             find_newest_session_for_cwd(tmp.path().join(".codex/sessions").as_path(), cwd).unwrap();
         let global_newest =
             find_newest_session(tmp.path().join(".codex/sessions").as_path()).unwrap();
         assert!(newest_match.is_some());
         assert_ne!(newest_match, global_newest);
+    }
+
+    #[test]
+    fn test_find_newest_session_prefers_newer_partition_on_mtime_tie() {
+        let tmp = tempdir().unwrap();
+        let sessions_root = tmp.path().join(".codex/sessions");
+        let day_old = sessions_root.join("2025/08/22");
+        let day_new = sessions_root.join("2025/09/14");
+        fs::create_dir_all(&day_old).unwrap();
+        fs::create_dir_all(&day_new).unwrap();
+
+        let old_session = day_old.join("rollout-2025-08-22T10-00-00-uuid.jsonl");
+        let new_session = day_new.join("rollout-2025-09-14T10-00-00-uuid.jsonl");
+        write_jsonl_with_cwd(&old_session, "/repo/worktree-a");
+        write_jsonl_without_cwd(&new_session);
+
+        let tie_time = FileTime::from_unix_time(1_726_782_400, 0);
+        set_file_mtime(&old_session, tie_time).unwrap();
+        set_file_mtime(&new_session, tie_time).unwrap();
+
+        let global_newest = find_newest_session(sessions_root.as_path()).unwrap();
+        assert_eq!(global_newest, Some(new_session));
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -685,6 +685,8 @@ fn main() {
             set_session_preferences,
             get_auto_commit_on_review,
             set_auto_commit_on_review,
+            get_keyboard_shortcuts,
+            set_keyboard_shortcuts,
             get_project_settings,
             set_project_settings,
             get_project_selection,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { SchaltEvent, listenEvent } from './common/eventSystem'
+import { useMultipleShortcutDisplays } from './keyboardShortcuts/useShortcutDisplay'
+import { KeyboardShortcutAction } from './keyboardShortcuts/config'
 import { Sidebar } from './components/sidebar/Sidebar'
 import { TerminalGrid } from './components/terminal/TerminalGrid'
 import { RightPanelTabs } from './components/right-panel/RightPanelTabs'
@@ -41,7 +43,6 @@ import { startSessionTop, computeProjectOrchestratorId } from './common/agentSpa
 import { logger } from './utils/logger'
 import { installSmartDashGuards } from './utils/normalizeCliText'
 import { useKeyboardShortcutsConfig } from './contexts/KeyboardShortcutsContext'
-import { KeyboardShortcutAction } from './keyboardShortcuts/config'
 import { detectPlatformSafe, isShortcutForAction } from './keyboardShortcuts/helpers'
 import { useSelectionPreserver } from './hooks/useSelectionPreserver'
 
@@ -58,6 +59,13 @@ export default function App() {
   const { increaseFontSizes, decreaseFontSizes, resetFontSizes } = useFontSize()
   const { isOnboardingOpen, completeOnboarding, closeOnboarding, openOnboarding } = useOnboarding()
   const { fetchSessionForPrefill } = useSessionPrefill()
+
+  // Get dynamic shortcut displays
+  const shortcuts = useMultipleShortcutDisplays([
+    KeyboardShortcutAction.NewSession,
+    KeyboardShortcutAction.NewSpec
+  ])
+
   const [newSessionOpen, setNewSessionOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [cancelModalOpen, setCancelModalOpen] = useState(false)
@@ -965,10 +973,12 @@ export default function App() {
                     }}
                     onMouseEnter={(e) => e.currentTarget.style.backgroundColor = `${theme.colors.background.hover}99`}
                     onMouseLeave={(e) => e.currentTarget.style.backgroundColor = `${theme.colors.background.elevated}99`}
-                    title="Start agent (⌘N)"
+                    title={`Start agent (${shortcuts[KeyboardShortcutAction.NewSession] || '⌘N'})`}
                   >
                     <span>Start Agent</span>
-                    <span className="text-xs opacity-60 group-hover:opacity-100 transition-opacity">⌘N</span>
+                    <span className="text-xs opacity-60 group-hover:opacity-100 transition-opacity">
+                      {shortcuts[KeyboardShortcutAction.NewSession] || '⌘N'}
+                    </span>
                   </button>
                   <button
                     onClick={() => {
@@ -988,10 +998,12 @@ export default function App() {
                     onMouseLeave={(e) => {
                       e.currentTarget.style.backgroundColor = theme.colors.accent.amber.bg
                     }}
-                    title="Create spec (⇧⌘N)"
+                    title={`Create spec (${shortcuts[KeyboardShortcutAction.NewSpec] || '⇧⌘N'})`}
                   >
                     <span>Create Spec</span>
-                    <span className="text-xs opacity-60 group-hover:opacity-100 transition-opacity">⇧⌘N</span>
+                    <span className="text-xs opacity-60 group-hover:opacity-100 transition-opacity">
+                      {shortcuts[KeyboardShortcutAction.NewSpec] || '⇧⌘N'}
+                    </span>
                   </button>
                 </div>
               </div>

--- a/src/components/common/ShortcutHint.test.tsx
+++ b/src/components/common/ShortcutHint.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ShortcutHint } from './ShortcutHint'
+import { KeyboardShortcutAction } from '../../keyboardShortcuts/config'
+
+// Mock the useShortcutDisplay hook
+vi.mock('../../keyboardShortcuts/useShortcutDisplay', () => ({
+  useShortcutDisplay: (action: KeyboardShortcutAction) => {
+    const shortcuts: Record<KeyboardShortcutAction, string> = {
+      [KeyboardShortcutAction.FocusTerminal]: '⌘/',
+      [KeyboardShortcutAction.NewSession]: '⌘N',
+      [KeyboardShortcutAction.NewSpec]: '⌘⇧N',
+      [KeyboardShortcutAction.FocusClaude]: '⌘T',
+    } as Record<KeyboardShortcutAction, string>
+    return shortcuts[action] || ''
+  }
+}))
+
+describe('ShortcutHint', () => {
+  it('renders shortcut for given action', () => {
+    render(<ShortcutHint action={KeyboardShortcutAction.FocusTerminal} />)
+    expect(screen.getByText('⌘/')).toBeInTheDocument()
+  })
+
+  it('renders shortcut with shift symbol', () => {
+    render(<ShortcutHint action={KeyboardShortcutAction.NewSpec} />)
+    expect(screen.getByText('⌘⇧N')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    render(<ShortcutHint action={KeyboardShortcutAction.FocusTerminal} className="test-class" />)
+    const element = screen.getByText('⌘/')
+    expect(element).toHaveClass('test-class')
+  })
+
+  it('shows fallback when shortcut is not configured', () => {
+    render(<ShortcutHint action={KeyboardShortcutAction.IncreaseFontSize} fallback="N/A" />)
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  it('renders nothing when no shortcut and no fallback', () => {
+    const { container } = render(<ShortcutHint action={KeyboardShortcutAction.IncreaseFontSize} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/components/common/ShortcutHint.tsx
+++ b/src/components/common/ShortcutHint.tsx
@@ -1,0 +1,27 @@
+import { KeyboardShortcutAction } from '../../keyboardShortcuts/config'
+import { useShortcutDisplay } from '../../keyboardShortcuts/useShortcutDisplay'
+
+interface ShortcutHintProps {
+  action: KeyboardShortcutAction
+  className?: string
+  fallback?: string
+}
+
+/**
+ * Reusable component to display keyboard shortcut hints.
+ * Automatically shows the current configured shortcut for the given action.
+ */
+export function ShortcutHint({ action, className = '', fallback = '' }: ShortcutHintProps) {
+  const shortcut = useShortcutDisplay(action)
+  const displayText = shortcut || fallback
+
+  if (!displayText) {
+    return null
+  }
+
+  return (
+    <span className={className}>
+      {displayText}
+    </span>
+  )
+}

--- a/src/components/terminal/TerminalGrid.test.tsx
+++ b/src/components/terminal/TerminalGrid.test.tsx
@@ -272,6 +272,37 @@ vi.mock('../../utils/runScriptLoader', () => ({
   loadRunScriptConfiguration: loadRunScriptConfigurationMock,
 }))
 
+// Mock platform detection to return mac for consistent symbols
+vi.mock('../../keyboardShortcuts/helpers', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    detectPlatformSafe: () => 'mac'
+  }
+})
+
+// Mock the useShortcutDisplay hook to return Mac shortcuts
+vi.mock('../../keyboardShortcuts/useShortcutDisplay', () => ({
+  useShortcutDisplay: (action: string) => {
+    const shortcuts: Record<string, string> = {
+      'FocusTerminal': '⌘/',
+      'ToggleRunMode': '⌘E',
+    }
+    return shortcuts[action] || ''
+  },
+  useMultipleShortcutDisplays: (actions: string[]) => {
+    const shortcuts: Record<string, string> = {
+      'FocusTerminal': '⌘/',
+      'ToggleRunMode': '⌘E',
+    }
+    const result: Record<string, string> = {}
+    for (const action of actions) {
+      result[action] = shortcuts[action] || ''
+    }
+    return result
+  }
+}))
+
 // Mock Tauri core invoke used by SelectionContext (providers in tests)
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -18,6 +18,8 @@ import { getActionButtonColorClasses } from '../../constants/actionButtonColors'
 import { ConfirmResetDialog } from '../common/ConfirmResetDialog'
 import { VscDiscard } from 'react-icons/vsc'
 import { useRef, useEffect, useState, useMemo, useCallback } from 'react'
+import { useShortcutDisplay } from '../../keyboardShortcuts/useShortcutDisplay'
+import { KeyboardShortcutAction } from '../../keyboardShortcuts/config'
 import { mapSessionUiState } from '../../utils/sessionFilters'
 import { logger } from '../../utils/logger'
 import { loadRunScriptConfiguration } from '../../utils/runScriptLoader'
@@ -52,7 +54,10 @@ export function TerminalGrid() {
     const { actionButtons } = useActionButtons()
     const { sessions } = useSessions()
     const { isAnyModalOpen } = useModal()
-    
+
+    // Get dynamic shortcut for Focus Claude
+    const focusClaudeShortcut = useShortcutDisplay(KeyboardShortcutAction.FocusClaude)
+
     // Show action buttons for both orchestrator and sessions
     const shouldShowActionButtons = (selection.kind === 'orchestrator' || selection.kind === 'session') && actionButtons.length > 0
     
@@ -897,7 +902,9 @@ export function TerminalGrid() {
                             localFocus === 'claude' 
                                 ? 'bg-blue-600/40 text-blue-200' 
                                 : 'bg-slate-700/50 text-slate-400'
-                        }`} title="Focus Claude (⌘T)">⌘T</span>
+                        }`} title={`Focus Claude (${focusClaudeShortcut || '⌘T'})`}>
+                            {focusClaudeShortcut || '⌘T'}
+                        </span>
                     </div>
                     <div className={`h-[2px] flex-shrink-0 ${
                         localFocus === 'claude' && !isDraggingSplit

--- a/src/components/terminal/UnifiedBottomBar.tsx
+++ b/src/components/terminal/UnifiedBottomBar.tsx
@@ -3,13 +3,15 @@ import { VscChevronDown, VscChevronUp } from 'react-icons/vsc'
 import { UnifiedTab } from '../UnifiedTab'
 import { theme } from '../../common/theme'
 import { TabInfo } from '../../types/terminalTabs'
-import { 
-    canCloseTab, 
+import {
+    canCloseTab,
     isRunTab,
     getRunButtonIcon,
     getRunButtonLabel,
     getRunButtonTooltip
 } from './UnifiedBottomBar.logic'
+import { useMultipleShortcutDisplays } from '../../keyboardShortcuts/useShortcutDisplay'
+import { KeyboardShortcutAction } from '../../keyboardShortcuts/config'
 
 export interface UnifiedBottomBarProps {
   isCollapsed: boolean
@@ -43,6 +45,12 @@ export const UnifiedBottomBar = forwardRef<HTMLDivElement, UnifiedBottomBarProps
   isRunning = false,
   onRunScript
 }, ref) => {
+  // Get dynamic shortcut displays
+  const shortcuts = useMultipleShortcutDisplays([
+    KeyboardShortcutAction.FocusTerminal,
+    KeyboardShortcutAction.ToggleRunMode
+  ])
+
   return (
     <div
       ref={ref}
@@ -144,7 +152,9 @@ export const UnifiedBottomBar = forwardRef<HTMLDivElement, UnifiedBottomBarProps
           >
             <span className="text-[11px]">{getRunButtonIcon(isRunning)}</span>
             <span className="text-[11px] font-medium">{getRunButtonLabel(isRunning)}</span>
-            <span className="text-[9px] opacity-60 ml-0.5">⌘E</span>
+            <span className="text-[9px] opacity-60 ml-0.5">
+              {shortcuts[KeyboardShortcutAction.ToggleRunMode] || '⌘E'}
+            </span>
           </button>
         )}
         
@@ -154,9 +164,10 @@ export const UnifiedBottomBar = forwardRef<HTMLDivElement, UnifiedBottomBarProps
               ? 'bg-blue-600/40 text-blue-200'
               : 'bg-slate-700/50 text-slate-400'
           }`} 
-          title="Focus Terminal (⌘/)"
+          title={`Focus Terminal (${shortcuts[KeyboardShortcutAction.FocusTerminal] || '⌘/'})`}
         >
-          ⌘/
+          {shortcuts[KeyboardShortcutAction.FocusTerminal] || '⌘/'}
+
         </span>
         
         <button

--- a/src/keyboardShortcuts/helpers.test.ts
+++ b/src/keyboardShortcuts/helpers.test.ts
@@ -14,6 +14,11 @@ describe('getDisplayLabelForSegment', () => {
     expect(getDisplayLabelForSegment('Alt', 'mac')).toBe('⌥')
   })
 
+  it('converts Shift to shift symbol on all platforms', () => {
+    expect(getDisplayLabelForSegment('Shift', 'mac')).toBe('⇧')
+    expect(getDisplayLabelForSegment('Shift', 'windows')).toBe('⇧')
+  })
+
   it('keeps literal keys unchanged', () => {
     expect(getDisplayLabelForSegment('Enter', 'mac')).toBe('Enter')
     expect(getDisplayLabelForSegment('K', 'windows')).toBe('K')

--- a/src/keyboardShortcuts/helpers.ts
+++ b/src/keyboardShortcuts/helpers.ts
@@ -26,6 +26,7 @@ export const detectPlatformSafe = detectPlatform
 
 const MAC_CMD_SYMBOL = '⌘'
 const MAC_ALT_SYMBOL = '⌥'
+const SHIFT_SYMBOL = '⇧'
 
 export const getDisplayLabelForSegment = (segment: string, platform: Platform): string => {
   switch (segment) {
@@ -38,7 +39,7 @@ export const getDisplayLabelForSegment = (segment: string, platform: Platform): 
     case 'Alt':
       return platform === 'mac' ? MAC_ALT_SYMBOL : 'Alt'
     case 'Shift':
-      return 'Shift'
+      return SHIFT_SYMBOL
     default:
       return segment
   }

--- a/src/keyboardShortcuts/useShortcutDisplay.test.tsx
+++ b/src/keyboardShortcuts/useShortcutDisplay.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useShortcutDisplay, useMultipleShortcutDisplays } from './useShortcutDisplay'
+import { KeyboardShortcutAction } from './config'
+// KeyboardShortcutsProvider mocked below
+
+// Mock the context to provide test data
+vi.mock('../contexts/KeyboardShortcutsContext', () => ({
+  KeyboardShortcutsProvider: ({ children }: { children: React.ReactNode }) => children,
+  useKeyboardShortcutsConfig: () => ({
+    config: {
+      [KeyboardShortcutAction.FocusTerminal]: ['Mod+/'],
+      [KeyboardShortcutAction.NewSession]: ['Mod+N'],
+      [KeyboardShortcutAction.NewSpec]: ['Mod+Shift+N'],
+      [KeyboardShortcutAction.FocusClaude]: ['Mod+T'],
+    },
+    loading: false,
+    setConfig: vi.fn(),
+    applyOverrides: vi.fn(),
+    resetToDefaults: vi.fn(),
+    refresh: vi.fn(),
+  })
+}))
+
+// Mock platform detection to return mac for consistent symbols
+vi.mock('./helpers', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    detectPlatformSafe: () => 'mac'
+  }
+})
+
+describe('useShortcutDisplay', () => {
+  it('returns formatted shortcut for single action', () => {
+    const { result } = renderHook(() => useShortcutDisplay(KeyboardShortcutAction.FocusTerminal))
+    expect(result.current).toBe('⌘/')
+  })
+
+  it('returns formatted shortcut with shift symbol', () => {
+    const { result } = renderHook(() => useShortcutDisplay(KeyboardShortcutAction.NewSpec))
+    expect(result.current).toBe('⌘⇧N')
+  })
+
+  it('returns empty string for action with no binding', () => {
+    const { result } = renderHook(() => useShortcutDisplay(KeyboardShortcutAction.IncreaseFontSize))
+    expect(result.current).toBe('')
+  })
+})
+
+describe('useMultipleShortcutDisplays', () => {
+  it('returns formatted shortcuts for multiple actions', () => {
+    const actions = [
+      KeyboardShortcutAction.FocusTerminal,
+      KeyboardShortcutAction.NewSession,
+      KeyboardShortcutAction.FocusClaude
+    ]
+
+    const { result } = renderHook(() => useMultipleShortcutDisplays(actions))
+
+    expect(result.current).toEqual({
+      [KeyboardShortcutAction.FocusTerminal]: '⌘/',
+      [KeyboardShortcutAction.NewSession]: '⌘N',
+      [KeyboardShortcutAction.FocusClaude]: '⌘T',
+    })
+  })
+
+  it('returns empty string for actions with no bindings', () => {
+    const actions = [KeyboardShortcutAction.IncreaseFontSize]
+
+    const { result } = renderHook(() => useMultipleShortcutDisplays(actions))
+
+    expect(result.current).toEqual({
+      [KeyboardShortcutAction.IncreaseFontSize]: '',
+    })
+  })
+})

--- a/src/keyboardShortcuts/useShortcutDisplay.ts
+++ b/src/keyboardShortcuts/useShortcutDisplay.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+import { useKeyboardShortcutsConfig } from '../contexts/KeyboardShortcutsContext'
+import { KeyboardShortcutAction } from './config'
+import { detectPlatformSafe, getDisplayLabelForSegment, splitShortcutBinding } from './helpers'
+
+/**
+ * Hook to get the display string for a keyboard shortcut action.
+ * Returns the formatted shortcut (e.g., "⌘T", "⌘<", "Ctrl+N") based on the current configuration.
+ */
+export function useShortcutDisplay(action: KeyboardShortcutAction): string {
+  const keyboardShortcuts = useKeyboardShortcutsConfig()
+  const platform = detectPlatformSafe()
+
+  return useMemo(() => {
+    const bindings = keyboardShortcuts.config[action]
+    if (!bindings || bindings.length === 0) {
+      // Return empty string if no binding exists
+      return ''
+    }
+
+    // Use the first binding if multiple exist
+    const binding = bindings[0]
+    const segments = splitShortcutBinding(binding)
+    return segments.map(seg => getDisplayLabelForSegment(seg, platform)).join('')
+  }, [keyboardShortcuts.config, action, platform])
+}
+
+/**
+ * Hook to get multiple shortcut displays at once for better performance.
+ * Returns an object mapping actions to their display strings.
+ */
+export function useMultipleShortcutDisplays(actions: KeyboardShortcutAction[]): Record<KeyboardShortcutAction, string> {
+  const keyboardShortcuts = useKeyboardShortcutsConfig()
+  const platform = detectPlatformSafe()
+
+  return useMemo(() => {
+    const result = {} as Record<KeyboardShortcutAction, string>
+
+    for (const action of actions) {
+      const bindings = keyboardShortcuts.config[action]
+      if (!bindings || bindings.length === 0) {
+        result[action] = ''
+        continue
+      }
+
+      const binding = bindings[0]
+      const segments = splitShortcutBinding(binding)
+      result[action] = segments.map(seg => getDisplayLabelForSegment(seg, platform)).join('')
+    }
+
+    return result
+  }, [keyboardShortcuts.config, actions, platform])
+}


### PR DESCRIPTION
## Summary
- rename the MCP tool from `schaltwerk_draft_create` to `schaltwerk_spec_create` and align generated names
- add a guard test to ensure the registry keeps advertising the new spec-first command
- retire obsolete Jest suites that targeted the deprecated bridge internals and fix the remaining null-handling expectations

## Testing
- npm test
- (cd mcp-server && npm test)
- (cd mcp-server && npm run build)
