### PR TITLE
Add configurable session branch prefix per project

### DIFF
--- a/src-tauri/src/domains/git/branches.rs
+++ b/src-tauri/src/domains/git/branches.rs
@@ -1,4 +1,5 @@
 use super::repository::{get_unborn_head_branch, repository_has_commits};
+use crate::schaltwerk_core::db_project_config::DEFAULT_BRANCH_PREFIX;
 use anyhow::{anyhow, Result};
 use git2::{BranchType, Repository};
 use std::path::Path;
@@ -115,7 +116,14 @@ pub fn archive_branch(repo_path: &Path, branch_name: &str, session_name: &str) -
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let archived_branch = format!("schaltwerk/archived/{timestamp}/{session_name}");
+    let prefix = branch_name
+        .strip_suffix(session_name)
+        .and_then(|base| base.strip_suffix('/'))
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
+
+    let archived_branch = format!("{prefix}/archived/{timestamp}/{session_name}");
 
     let repo = Repository::open(repo_path)?;
 

--- a/src-tauri/src/infrastructure/database/db_schema.rs
+++ b/src-tauri/src/infrastructure/database/db_schema.rs
@@ -104,6 +104,7 @@ pub fn initialize_schema(db: &Database) -> anyhow::Result<()> {
             setup_script TEXT,
             last_selection_kind TEXT,
             last_selection_payload TEXT,
+            branch_prefix TEXT DEFAULT 'schaltwerk',
             created_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL
         )",
@@ -260,5 +261,13 @@ fn apply_project_config_migrations(conn: &rusqlite::Connection) -> anyhow::Resul
         [],
     );
     let _ = conn.execute("ALTER TABLE project_config ADD COLUMN run_script TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE project_config ADD COLUMN branch_prefix TEXT",
+        [],
+    );
+    let _ = conn.execute(
+        "UPDATE project_config SET branch_prefix = 'schaltwerk' WHERE branch_prefix IS NULL",
+        [],
+    );
     Ok(())
 }

--- a/src/components/modals/SettingsModal.test.tsx
+++ b/src/components/modals/SettingsModal.test.tsx
@@ -111,7 +111,7 @@ const createDefaultUseSettingsValue = () => ({
   saveAllSettings: vi.fn().mockResolvedValue({ success: true, savedSettings: [], failedSettings: [] }),
   loadEnvVars: vi.fn().mockResolvedValue(createEmptyEnvVars()),
   loadCliArgs: vi.fn().mockResolvedValue(createEmptyCliArgs()),
-  loadProjectSettings: vi.fn().mockResolvedValue({ setupScript: '', environmentVariables: [] }),
+  loadProjectSettings: vi.fn().mockResolvedValue({ setupScript: '', branchPrefix: 'schaltwerk', environmentVariables: [] }),
   loadTerminalSettings: vi.fn().mockResolvedValue({ shell: null, shellArgs: [], fontFamily: null }),
   loadSessionPreferences: vi.fn().mockResolvedValue({ auto_commit_on_review: false, skip_confirmation_modals: false }),
   loadKeyboardShortcuts: vi.fn().mockResolvedValue(defaultShortcutConfig),

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -159,6 +159,7 @@ const CATEGORIES: CategoryConfig[] = [
 
 interface ProjectSettings {
     setupScript: string
+    branchPrefix: string
     environmentVariables: Array<{key: string, value: string}>
 }
 
@@ -187,6 +188,7 @@ export function SettingsModal({ open, onClose, onOpenTutorial }: Props) {
     const [projectPath, setProjectPath] = useState<string>('')
     const [projectSettings, setProjectSettings] = useState<ProjectSettings>({
         setupScript: '',
+        branchPrefix: 'schaltwerk',
         environmentVariables: []
     })
     const [terminalSettings, setTerminalSettings] = useState<TerminalSettings>({
@@ -396,7 +398,7 @@ export function SettingsModal({ open, onClose, onOpenTutorial }: Props) {
         ])
         
         // Load project-specific settings (may fail if no project is open)
-        let loadedProjectSettings: ProjectSettings = { setupScript: '', environmentVariables: [] }
+        let loadedProjectSettings: ProjectSettings = { setupScript: '', branchPrefix: 'schaltwerk', environmentVariables: [] }
         let loadedTerminalSettings: TerminalSettings = { shell: null, shellArgs: [], fontFamily: null }
         let loadedRunScript: RunScript = { command: '', workingDirectory: '', environmentVariables: {} }
         
@@ -1045,6 +1047,23 @@ export function SettingsModal({ open, onClose, onOpenTutorial }: Props) {
         <div className="flex flex-col h-full">
             <div className="flex-1 overflow-y-auto p-6">
                 <div className="space-y-4">
+                    <div>
+                        <h3 className="text-body font-medium text-slate-200 mb-2">Branch Prefix</h3>
+                        <div className="text-body text-slate-400 mb-3">
+                            Configure the default Git branch prefix used when creating new Schaltwerk sessions. Use slashes to nest groups (for example <code className={theme.colors.accent.blue.DEFAULT}>team/frontend</code>). Spaces will be converted to hyphens automatically.
+                        </div>
+                        <input
+                            type="text"
+                            value={projectSettings.branchPrefix}
+                            onChange={(e) => {
+                                const sanitized = e.target.value.replace(/\s+/g, '-');
+                                setProjectSettings(prev => ({ ...prev, branchPrefix: sanitized }));
+                            }}
+                            placeholder="schaltwerk"
+                            className={`w-full bg-slate-800 text-slate-100 rounded px-3 py-2 border border-slate-700 placeholder-slate-500 text-body focus:outline-none focus:${theme.colors.border.focus} transition-colors`}
+                            spellCheck={false}
+                        />
+                    </div>
                     <div>
                         <h3 className="text-body font-medium text-slate-200 mb-2">Worktree Setup Script</h3>
                         <div className="text-body text-slate-400 mb-4">

--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -103,6 +103,7 @@ describe('useSettings', () => {
       
       const projectSettings = {
         setupScript: 'npm install && npm run build',
+        branchPrefix: 'feature',
         environmentVariables: [
           { key: 'NODE_ENV', value: 'production' },
           { key: 'PORT', value: '3000' }
@@ -114,7 +115,7 @@ describe('useSettings', () => {
       })
 
       expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetProjectSettings, {
-        settings: { setupScript: 'npm install && npm run build' }
+        settings: { setupScript: 'npm install && npm run build', branchPrefix: 'feature' }
       })
       expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetProjectEnvironmentVariables, {
         envVars: {
@@ -129,6 +130,7 @@ describe('useSettings', () => {
       
       const projectSettings = {
         setupScript: '',
+        branchPrefix: 'feature',
         environmentVariables: [
           { key: 'VALID', value: 'yes' },
           { key: '', value: 'no-key' }
@@ -223,7 +225,8 @@ describe('useSettings', () => {
       
       const projectSettings = {
         setupScript: '',
-        environmentVariables: []
+        environmentVariables: [],
+        branchPrefix: 'feature'
       }
       
       const terminalSettings = {
@@ -281,7 +284,8 @@ describe('useSettings', () => {
       
       const projectSettings = {
         setupScript: '',
-        environmentVariables: []
+        environmentVariables: [],
+        branchPrefix: 'feature'
       }
       
       const terminalSettings = {
@@ -413,7 +417,7 @@ describe('useSettings', () => {
     it('loads project settings and environment variables', async () => {
       mockInvoke.mockImplementation((command: string) => {
         if (command === TauriCommands.GetProjectSettings) {
-          return Promise.resolve({ setupScript: 'npm install' })
+          return Promise.resolve({ setupScript: 'npm install', branchPrefix: 'team' })
         }
         if (command === 'get_project_environment_variables') {
           return Promise.resolve({ NODE_ENV: 'test', DEBUG: 'true' })
@@ -429,6 +433,7 @@ describe('useSettings', () => {
 
       expect(settings).toEqual({
         setupScript: 'npm install',
+        branchPrefix: 'team',
         environmentVariables: [
           { key: 'NODE_ENV', value: 'test' },
           { key: 'DEBUG', value: 'true' }
@@ -447,6 +452,7 @@ describe('useSettings', () => {
 
       expect(settings).toEqual({
         setupScript: '',
+        branchPrefix: 'schaltwerk',
         environmentVariables: []
       })
     })
@@ -470,6 +476,7 @@ describe('useSettings', () => {
 
       expect(settings).toEqual({
         setupScript: '',
+        branchPrefix: 'schaltwerk',
         environmentVariables: []
       })
     })


### PR DESCRIPTION
## Summary
- persist a project-level branch prefix with normalization and schema migrations
- apply the configured prefix across session creation, renaming, and archival flows
- expose branch prefix controls in project settings with sanitization and updated tests

## Testing
- just test