### PR TITLE
Refactor session state helpers to remove duplication

### DIFF
--- a/src/utils/sessionFilters.ts
+++ b/src/utils/sessionFilters.ts
@@ -1,25 +1,7 @@
-import { EnrichedSession, SessionInfo } from '../types/session'
+import { EnrichedSession } from '../types/session'
+import { isReviewed, isRunning, isSpec, mapSessionUiState } from './sessionState'
 
-// These types are now imported from the centralized types/session.ts file
-
-// Normalize backend states to UI categories
-export function mapSessionUiState(info: SessionInfo): 'spec' | 'running' | 'reviewed' {
-    if (info.session_state === 'spec' || info.status === 'spec') return 'spec'
-    if (info.ready_to_merge) return 'reviewed'
-    return 'running'
-}
-
-export function isSpec(info: SessionInfo): boolean { 
-    return mapSessionUiState(info) === 'spec' 
-}
-
-export function isReviewed(info: SessionInfo): boolean { 
-    return mapSessionUiState(info) === 'reviewed' 
-}
-
-export function isRunning(info: SessionInfo): boolean {
-    return !isReviewed(info) && !isSpec(info)
-}
+export { mapSessionUiState, isSpec, isReviewed, isRunning }
 
 /**
  * Calculate filter counts for sessions

--- a/src/utils/sessionState.ts
+++ b/src/utils/sessionState.ts
@@ -1,0 +1,30 @@
+import type { SessionInfo } from '../types/session'
+import { SessionState } from '../types/session'
+
+type SessionStateSource = Pick<SessionInfo, 'session_state' | 'status' | 'ready_to_merge'>
+
+export type SessionUiState = SessionState.Spec | SessionState.Running | SessionState.Reviewed
+
+export function mapSessionUiState(info: SessionStateSource): SessionUiState {
+    if (info.session_state === SessionState.Spec || info.status === 'spec') {
+        return SessionState.Spec
+    }
+
+    if (info.ready_to_merge) {
+        return SessionState.Reviewed
+    }
+
+    return SessionState.Running
+}
+
+export function isSpec(info: SessionStateSource): boolean {
+    return mapSessionUiState(info) === SessionState.Spec
+}
+
+export function isReviewed(info: SessionStateSource): boolean {
+    return mapSessionUiState(info) === SessionState.Reviewed
+}
+
+export function isRunning(info: SessionStateSource): boolean {
+    return mapSessionUiState(info) === SessionState.Running
+}


### PR DESCRIPTION
## Summary
- extract shared session state helpers into a dedicated utility and re-export them from the filters module
- update the session organizer logic to consume the shared helpers and refresh its tests to use consistent fixtures

## Testing
- just test

------
https://chatgpt.com/codex/tasks/task_e_68da71dcee5c832ab03dba8fd8afd644