### PR TITLE
Refine shared date formatting usage

### DIFF
--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -8,6 +8,11 @@ import { NewProjectDialog } from './NewProjectDialog'
 import { getHomeLogoPositionStyles, getContentAreaStyles } from '../../constants/layout'
 import { logger } from '../../utils/logger'
 import { theme } from '../../common/theme'
+import { formatDateTime } from '../../utils/dateTime'
+
+const RECENT_PROJECT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  dateStyle: 'medium'
+}
 
 interface RecentProject {
   path: string
@@ -196,7 +201,7 @@ export function HomeScreen({ onOpenProject }: HomeScreenProps) {
                           {project.path}
                         </p>
                         <p className="text-slate-600 text-xs mt-2">
-                          {new Date(project.lastOpened).toLocaleDateString()}
+                          {formatDateTime(project.lastOpened, RECENT_PROJECT_DATE_OPTIONS)}
                         </p>
                       </div>
                     </div>

--- a/src/components/plans/SpecMetadataPanel.tsx
+++ b/src/components/plans/SpecMetadataPanel.tsx
@@ -6,6 +6,15 @@ import { theme } from '../../common/theme'
 import { AnimatedText } from '../common/AnimatedText'
 import { SessionActions } from '../session/SessionActions'
 import { logger } from '../../utils/logger'
+import { formatDateTime } from '../../utils/dateTime'
+
+const METADATA_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+}
 
 interface SpecMetadata {
   created_at?: string
@@ -41,22 +50,6 @@ export function SpecMetadataPanel({ sessionName }: Props) {
 
     loadMetadata()
   }, [sessionName])
-
-  const formatDate = (dateStr?: string) => {
-    if (!dateStr) return 'Unknown'
-    try {
-      const date = new Date(dateStr)
-      return date.toLocaleDateString('en-US', { 
-        month: 'short', 
-        day: 'numeric', 
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit'
-      })
-    } catch {
-      return 'Unknown'
-    }
-  }
 
   if (loading) {
     return (
@@ -131,7 +124,7 @@ export function SpecMetadataPanel({ sessionName }: Props) {
               color: theme.colors.text.primary, 
               fontSize: theme.fontSize.body 
             }}>
-              {formatDate(metadata.created_at)}
+              {formatDateTime(metadata.created_at, METADATA_DATE_OPTIONS, 'Unknown', 'en-US')}
             </div>
           </div>
         </div>
@@ -154,7 +147,7 @@ export function SpecMetadataPanel({ sessionName }: Props) {
                 color: theme.colors.text.primary, 
                 fontSize: theme.fontSize.body 
               }}>
-                {formatDate(metadata.updated_at)}
+                {formatDateTime(metadata.updated_at, METADATA_DATE_OPTIONS, 'Unknown', 'en-US')}
               </div>
             </div>
           </div>

--- a/src/components/settings/SettingsArchivesSection.tsx
+++ b/src/components/settings/SettingsArchivesSection.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { AnimatedText } from '../common/AnimatedText'
 import { logger } from '../../utils/logger'
 import { TauriCommands } from '../../common/tauriCommands'
+import { formatDateTime } from '../../utils/dateTime'
 
 type NotificationType = 'success' | 'error' | 'info'
 
@@ -37,17 +38,6 @@ export function SettingsArchivesSection({ onClose: _onClose, onOpenSpec, onNotif
         return () => {
             isMountedRef.current = false
         }
-    }, [])
-
-    const formatTimestamp = useCallback((value: number | string) => {
-        let timestamp: number
-        if (typeof value === 'number') {
-            timestamp = value > 1e12 ? value : value * 1000
-        } else {
-            const parsed = Date.parse(value)
-            timestamp = Number.isNaN(parsed) ? Date.now() : parsed
-        }
-        return new Date(timestamp).toLocaleString()
     }, [])
 
     const fetchArchives = useCallback(async () => {
@@ -147,7 +137,7 @@ export function SettingsArchivesSection({ onClose: _onClose, onOpenSpec, onNotif
                             onClick={() => onOpenSpec({ name: item.session_name, content: item.content })}
                         >
                             <div className="text-slate-200 text-body truncate">{item.session_name}</div>
-                            <div className="text-caption text-slate-500">{formatTimestamp(item.archived_at)}</div>
+                            <div className="text-caption text-slate-500">{formatDateTime(item.archived_at)}</div>
                             <div className="text-caption text-slate-500 line-clamp-2 mt-1 break-all overflow-hidden max-w-full">{item.content}</div>
                         </div>
                         <div className="flex items-center gap-2 flex-shrink-0">
@@ -168,7 +158,7 @@ export function SettingsArchivesSection({ onClose: _onClose, onOpenSpec, onNotif
                 ))}
             </div>
         )
-    }, [archives, archivesLoading, formatTimestamp, handleDelete, handleRestore, loadError, onOpenSpec])
+    }, [archives, archivesLoading, handleDelete, handleRestore, loadError, onOpenSpec])
 
     return (
         <div className="flex flex-col h-full">

--- a/src/utils/dateTime.test.ts
+++ b/src/utils/dateTime.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { formatDateTime, normalizeDateInput } from './dateTime'
+
+describe('normalizeDateInput', () => {
+  it('returns a Date for ISO strings', () => {
+    const result = normalizeDateInput('2024-01-15T12:30:00Z')
+    expect(result).toBeInstanceOf(Date)
+    expect(result?.toISOString()).toBe('2024-01-15T12:30:00.000Z')
+  })
+
+  it('handles unix timestamps provided in seconds', () => {
+    const seconds = 1_700_000_000
+    const result = normalizeDateInput(seconds)
+    expect(result).toBeInstanceOf(Date)
+    expect(result?.getTime()).toBe(seconds * 1000)
+  })
+
+  it('handles unix timestamps provided in milliseconds', () => {
+    const milliseconds = 1_700_000_000_000
+    const result = normalizeDateInput(milliseconds)
+    expect(result).toBeInstanceOf(Date)
+    expect(result?.getTime()).toBe(milliseconds)
+  })
+
+  it('returns null for invalid values', () => {
+    expect(normalizeDateInput('')).toBeNull()
+    expect(normalizeDateInput('not-a-date')).toBeNull()
+    expect(normalizeDateInput(Number.NaN)).toBeNull()
+    expect(normalizeDateInput(undefined)).toBeNull()
+  })
+})
+
+describe('formatDateTime', () => {
+  it('returns fallback when no valid date is provided', () => {
+    expect(formatDateTime(undefined, undefined, 'N/A')).toBe('N/A')
+    expect(formatDateTime('not-a-date')).toBe('Unknown')
+  })
+
+  it('formats using provided locale and options', () => {
+    const spy = vi.spyOn(Date.prototype, 'toLocaleString').mockReturnValue('formatted')
+
+    const result = formatDateTime('2024-01-15T12:30:00Z', { timeZone: 'UTC' }, 'Unknown', 'en-US')
+
+    expect(result).toBe('formatted')
+    expect(spy).toHaveBeenCalledWith('en-US', { timeZone: 'UTC' })
+
+    spy.mockRestore()
+  })
+
+  it('formats using default locale when none is supplied', () => {
+    const spy = vi.spyOn(Date.prototype, 'toLocaleString').mockReturnValue('formatted-default')
+
+    const result = formatDateTime(1_700_000_000)
+
+    expect(result).toBe('formatted-default')
+    expect(spy).toHaveBeenCalledWith(undefined)
+
+    spy.mockRestore()
+  })
+})

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -1,0 +1,53 @@
+export type DateInput = Date | string | number | null | undefined
+
+const MS_THRESHOLD = 1_000_000_000_000
+
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime())
+}
+
+export function normalizeDateInput(input: DateInput): Date | null {
+  if (input === null || input === undefined) {
+    return null
+  }
+
+  if (input instanceof Date) {
+    return isValidDate(input) ? input : null
+  }
+
+  if (typeof input === 'number') {
+    const timestamp = input > MS_THRESHOLD ? input : input * 1000
+    const date = new Date(timestamp)
+    return isValidDate(date) ? date : null
+  }
+
+  if (typeof input === 'string') {
+    const trimmed = input.trim()
+    if (!trimmed) {
+      return null
+    }
+
+    const date = new Date(trimmed)
+    return isValidDate(date) ? date : null
+  }
+
+  return null
+}
+
+export function formatDateTime(
+  input: DateInput,
+  options?: Intl.DateTimeFormatOptions,
+  fallback = 'Unknown',
+  locale?: string | string[]
+): string {
+  const date = normalizeDateInput(input)
+  if (!date) {
+    return fallback
+  }
+
+  try {
+    return options ? date.toLocaleString(locale, options) : date.toLocaleString(locale)
+  } catch {
+    return fallback
+  }
+}


### PR DESCRIPTION
## Summary
- reuse the shared date/time formatter for home screen recent project timestamps
- define reusable date formatting options for the home screen so the helper can be shared consistently
- update the settings archives panel to call the shared date formatter instead of a local timestamp helper

## Testing
- npx vitest run src/components/settings/__tests__/SettingsArchivesSection.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da71df639c832abb081fdeb30efce7