### PR TITLE
Refactor session display name handling

### DIFF
--- a/src/components/shared/SessionCard.tsx
+++ b/src/components/shared/SessionCard.tsx
@@ -5,6 +5,7 @@ import { SessionActions } from '../session/SessionActions'
 import { SessionInfo, SessionMonitorStatus } from '../../types/session'
 import { UncommittedIndicator } from '../common/UncommittedIndicator'
 import { theme } from '../../common/theme'
+import { getSessionDisplayName } from '../../utils/sessionDisplayName'
 
 export interface SessionCardProps {
     session: {
@@ -52,7 +53,7 @@ export const SessionCard = memo(forwardRef<HTMLDivElement, SessionCardProps>(({
     isMarkReadyDisabled = false
 }, ref) => {
     const s = session.info
-    const sessionName = s.display_name || s.session_id
+    const sessionName = getSessionDisplayName(s)
     const currentAgent = s.current_task || `Working on ${sessionName}`
     const progressPercent = s.todo_percentage || 0
     const additions = s.diff_stats?.insertions || s.diff_stats?.additions || 0

--- a/src/components/sidebar/SessionButton.tsx
+++ b/src/components/sidebar/SessionButton.tsx
@@ -6,6 +6,7 @@ import { SessionInfo, SessionMonitorStatus } from '../../types/session'
 import { UncommittedIndicator } from '../common/UncommittedIndicator'
 import { theme } from '../../common/theme'
 import type { MergeStatus } from '../../contexts/SessionsContext'
+import { getSessionDisplayName } from '../../utils/sessionDisplayName'
 
 interface SessionButtonProps {
     session: {
@@ -82,7 +83,7 @@ export const SessionButton = memo<SessionButtonProps>(({
 }) => {
     const s = session.info
     const color = getSessionStateColor(s.session_state)
-    const sessionName = s.display_name || s.session_id
+    const sessionName = getSessionDisplayName(s)
     const currentAgent = s.current_task || `Working on ${sessionName}`
     const progressPercent = s.todo_percentage || 0
     const additions = s.diff_stats?.insertions || s.diff_stats?.additions || 0

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -31,6 +31,7 @@ import { EnrichedSession, SessionInfo } from '../../types/session'
 import { useRun } from '../../contexts/RunContext'
 import { useModal } from '../../contexts/ModalContext'
 import { useProject } from '../../contexts/ProjectContext'
+import { getSessionDisplayName } from '../../utils/sessionDisplayName'
 
 // Normalize backend states to UI categories
 function mapSessionUiState(info: SessionInfo): 'spec' | 'running' | 'reviewed' {
@@ -386,6 +387,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
         if (selection.kind === 'session') {
             const selectedSession = sessions.find(s => s.info.session_id === selection.payload)
             if (selectedSession) {
+                const sessionDisplayName = getSessionDisplayName(selectedSession.info)
                 // Check if it's a spec
                 if (isSpec(selectedSession.info)) {
                     // For specs, always show confirmation dialog (ignore immediate flag)
@@ -393,7 +395,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                         action: 'delete-spec',
                         sessionId: selectedSession.info.session_id,
                         sessionName: selectedSession.info.session_id,
-                        sessionDisplayName: selectedSession.info.display_name || selectedSession.info.session_id,
+                        sessionDisplayName,
                         branch: selectedSession.info.branch,
                         hasUncommittedChanges: false,
                     })
@@ -405,7 +407,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                             action: 'cancel-immediate',
                             sessionId: selectedSession.info.session_id,
                             sessionName: selectedSession.info.session_id,
-                            sessionDisplayName: selectedSession.info.display_name || selectedSession.info.session_id,
+                            sessionDisplayName,
                             branch: selectedSession.info.branch,
                             hasUncommittedChanges: selectedSession.info.has_uncommitted_changes || false,
                         })
@@ -414,7 +416,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                             action: 'cancel',
                             sessionId: selectedSession.info.session_id,
                             sessionName: selectedSession.info.session_id,
-                            sessionDisplayName: selectedSession.info.display_name || selectedSession.info.session_id,
+                            sessionDisplayName,
                             branch: selectedSession.info.branch,
                             hasUncommittedChanges: selectedSession.info.has_uncommitted_changes || false,
                         })
@@ -565,7 +567,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                 setConvertToDraftModal({
                     open: true,
                     sessionName: selectedSession.info.session_id,
-                    sessionDisplayName: selectedSession.info.display_name || selectedSession.info.session_id,
+                    sessionDisplayName: getSessionDisplayName(selectedSession.info),
                     hasUncommitted: selectedSession.info.has_uncommitted_changes || false
                 })
             }
@@ -1183,11 +1185,12 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                                     onCancel={(sessionId, hasUncommitted) => {
                                         const session = sessions.find(s => s.info.session_id === sessionId)
                                         if (session) {
+                                            const sessionDisplayName = getSessionDisplayName(session.info)
                                             emitUiEvent(UiEvent.SessionAction, {
                                                 action: 'cancel',
                                                 sessionId,
                                                 sessionName: sessionId,
-                                                sessionDisplayName: session.info.display_name || session.info.session_id,
+                                                sessionDisplayName,
                                                 branch: session.info.branch,
                                                 hasUncommittedChanges: hasUncommitted,
                                             })
@@ -1205,7 +1208,7 @@ export function Sidebar({ isDiffViewerOpen, openTabs = [], onSelectPrevProject, 
                                             setConvertToDraftModal({
                                                 open: true,
                                                 sessionName: sessionId,
-                                                sessionDisplayName: session.info.display_name || session.info.session_id,
+                                                sessionDisplayName: getSessionDisplayName(session.info),
                                                 hasUncommitted: session.info.has_uncommitted_changes || false
                                             })
                                         }

--- a/src/utils/sessionDisplayName.test.ts
+++ b/src/utils/sessionDisplayName.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getSessionDisplayName } from './sessionDisplayName'
+
+describe('getSessionDisplayName', () => {
+    it('returns the display name when present', () => {
+        expect(getSessionDisplayName({ session_id: 'abc', display_name: 'Feature X' })).toBe('Feature X')
+    })
+
+    it('falls back to the session id when display name missing', () => {
+        expect(getSessionDisplayName({ session_id: 'fallback', display_name: undefined })).toBe('fallback')
+    })
+
+    it('allows null display names', () => {
+        expect(getSessionDisplayName({ session_id: 'null-case', display_name: null })).toBe('null-case')
+    })
+})

--- a/src/utils/sessionDisplayName.ts
+++ b/src/utils/sessionDisplayName.ts
@@ -1,0 +1,10 @@
+import type { SessionInfo } from '../types/session'
+
+type SessionDisplaySource = Pick<SessionInfo, 'session_id' | 'display_name'> | {
+    session_id: string
+    display_name?: string | null
+}
+
+export function getSessionDisplayName(info: SessionDisplaySource): string {
+    return info.display_name || info.session_id
+}

--- a/src/utils/sessionFilters.ts
+++ b/src/utils/sessionFilters.ts
@@ -1,5 +1,6 @@
 import { EnrichedSession } from '../types/session'
 import { isReviewed, isRunning, isSpec, mapSessionUiState } from './sessionState'
+import { getSessionDisplayName } from './sessionDisplayName'
 
 export { mapSessionUiState, isSpec, isReviewed, isRunning }
 
@@ -24,7 +25,7 @@ export function searchSessions(sessions: EnrichedSession[], searchQuery: string)
     const query = searchQuery.toLowerCase().trim()
     return sessions.filter(session => {
         const sessionId = session.info.session_id.toLowerCase()
-        const displayName = (session.info.display_name || '').toLowerCase()
+        const displayName = getSessionDisplayName(session.info).toLowerCase()
         const specContent = (session.info.spec_content || '').toLowerCase()
         
         // Search in combined content

--- a/src/utils/sessionVersions.ts
+++ b/src/utils/sessionVersions.ts
@@ -1,6 +1,7 @@
 import { EnrichedSession } from '../types/session'
 import { TauriCommands } from '../common/tauriCommands'
 import { logger } from '../utils/logger'
+import { getSessionDisplayName } from './sessionDisplayName'
 
 export { type EnrichedSession }
 
@@ -100,8 +101,10 @@ export function groupSessionsByVersion(sessions: EnrichedSession[]): SessionVers
     // Sort versions by number (1, 2, 3, 4)
     versions.sort((a, b) => a.versionNumber - b.versionNumber)
     
+    const firstSessionInfo = versions[0]?.session.info
+    const defaultBaseName = firstSessionInfo ? getBaseSessionName(getSessionDisplayName(firstSessionInfo)) : ''
     // Use display name base if available, otherwise use session_id base
-    const displayBaseName = displayNameMap.get(groupKey) || getBaseSessionName(versions[0]?.session.info.display_name || versions[0]?.session.info.session_id)
+    const displayBaseName = displayNameMap.get(groupKey) || defaultBaseName
     
     result.push({
       baseName: displayBaseName,


### PR DESCRIPTION
## Summary
- add a shared `getSessionDisplayName` helper with unit coverage
- update session UI components to use the helper instead of duplicating fallback logic
- reuse the helper in filtering and version grouping utilities to keep naming behavior consistent

## Testing
- just test

------
https://chatgpt.com/codex/tasks/task_e_68da71de3c5c832aa24b2cd176f1c3a9