### PR TITLE
feat: Enhance MarkdownEditor with improved functionality and tests

### DIFF
--- a/src/components/plans/MarkdownEditor.test.tsx
+++ b/src/components/plans/MarkdownEditor.test.tsx
@@ -2,10 +2,11 @@ import { render } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { ComponentProps } from 'react'
 import type { Extension } from '@codemirror/state'
-import { MarkdownEditor } from './MarkdownEditor'
+import { MarkdownEditor, MARKDOWN_PASTE_CHARACTER_LIMIT, handleMarkdownPaste } from './MarkdownEditor'
 import type { ProjectFileIndexApi } from '../../hooks/useProjectFileIndex'
 
 const codeMirrorMock = vi.fn((props: unknown) => props)
+const pushToastMock = vi.fn()
 
 vi.mock('@uiw/react-codemirror', () => ({
   __esModule: true,
@@ -13,6 +14,12 @@ vi.mock('@uiw/react-codemirror', () => ({
     codeMirrorMock(props)
     return null
   },
+}))
+
+vi.mock('../../common/toast/ToastProvider', () => ({
+  useOptionalToast: () => ({
+    pushToast: pushToastMock,
+  }),
 }))
 
 function captureExtensions(extraProps: Partial<ComponentProps<typeof MarkdownEditor>> = {}): Extension[] {
@@ -36,6 +43,7 @@ function captureExtensions(extraProps: Partial<ComponentProps<typeof MarkdownEdi
 describe('MarkdownEditor', () => {
   beforeEach(() => {
     codeMirrorMock.mockClear()
+    pushToastMock.mockClear()
   })
 
   it('includes base extensions when no file reference provider is supplied', () => {
@@ -59,5 +67,49 @@ describe('MarkdownEditor', () => {
     const withProviderExtensions = captureExtensions({ fileReferenceProvider: provider })
 
     expect(withProviderExtensions.length).toBe(baseExtensions.length + 1)
+  })
+
+  it('blocks oversized paste operations and reports through toast', () => {
+    const largePayload = 'a'.repeat(MARKDOWN_PASTE_CHARACTER_LIMIT + 1)
+
+    const event = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    Object.defineProperty(event, 'preventDefault', { value: preventDefault, configurable: true })
+    Object.defineProperty(event, 'stopPropagation', { value: stopPropagation, configurable: true })
+    Object.defineProperty(event, 'clipboardData', {
+      value: {
+        getData: vi.fn(() => largePayload),
+      },
+    })
+    const handled = handleMarkdownPaste(event, { pushToast: pushToastMock })
+
+    expect(handled).toBe(true)
+    expect(preventDefault).toHaveBeenCalled()
+    expect(stopPropagation).toHaveBeenCalled()
+    expect(pushToastMock).toHaveBeenCalledWith(expect.objectContaining({
+      tone: 'warning',
+    }))
+  })
+
+  it('allows paste operations within the configured limit', () => {
+    const allowedPayload = 'b'.repeat(MARKDOWN_PASTE_CHARACTER_LIMIT)
+
+    const event = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    Object.defineProperty(event, 'preventDefault', { value: preventDefault, configurable: true })
+    Object.defineProperty(event, 'stopPropagation', { value: stopPropagation, configurable: true })
+    Object.defineProperty(event, 'clipboardData', {
+      value: {
+        getData: vi.fn(() => allowedPayload),
+      },
+    })
+    const handled = handleMarkdownPaste(event, { pushToast: pushToastMock })
+
+    expect(handled).toBe(false)
+    expect(pushToastMock).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Add paste size limit (200,000 characters) to prevent editor hangs
- Show warning toast when paste is blocked
- Add logging for blocked paste attempts
- Comprehensive test coverage for paste guard feature

Fixes #115

## Test plan
- [x] All existing tests pass
- [x] New test coverage for MarkdownEditor paste functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)