### PR TITLE
fix: restore Codex control shortcuts

### DIFF
--- a/src/components/terminal/terminalKeybindings.ts
+++ b/src/components/terminal/terminalKeybindings.ts
@@ -77,3 +77,23 @@ export function shouldHandleClaudeShiftEnter(
         !readOnly
     );
 }
+
+const isControlOnly = (event: KeyboardEvent): boolean => {
+    return event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+};
+
+const isKey = (event: KeyboardEvent, expected: string): boolean => {
+    return event.key?.toLowerCase() === expected.toLowerCase();
+};
+
+export function shouldEmitControlPaste(event: KeyboardEvent): boolean {
+    const platform = detectPlatformSafe();
+    if (platform !== 'mac') return false;
+    if (event.type !== 'keydown') return false;
+    return isControlOnly(event) && isKey(event, 'v');
+}
+
+export function shouldEmitControlNewline(event: KeyboardEvent): boolean {
+    if (event.type !== 'keydown') return false;
+    return isControlOnly(event) && isKey(event, 'j');
+}


### PR DESCRIPTION
## Summary
- add happy-dom regression tests for Codex ctrl+V/ctrl+J handling
- emit raw control sequences from Terminal so Codex pastes images and inserts newlines correctly

Fixes #121

## Testing
- just test
