### PR TITLE
Fix Codex orchestrator stuck on `resume exec`

### DIFF
--- a/src-tauri/src/domains/git/db_git_stats.rs
+++ b/src-tauri/src/domains/git/db_git_stats.rs
@@ -1,7 +1,8 @@
 use crate::domains::sessions::entity::GitStats;
+use crate::infrastructure::database::timestamps::utc_from_epoch_seconds_lossy;
 use crate::infrastructure::database::Database;
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
+use chrono::Utc;
 use rusqlite::params;
 
 pub trait GitStatsMethods {
@@ -46,7 +47,7 @@ impl GitStatsMethods for Database {
                 lines_added: row.get(2)?,
                 lines_removed: row.get(3)?,
                 has_uncommitted: row.get(4)?,
-                calculated_at: Utc.timestamp_opt(row.get(5)?, 0).unwrap(),
+                calculated_at: utc_from_epoch_seconds_lossy(row.get(5)?),
                 last_diff_change_ts: None,
             })
         });
@@ -69,7 +70,7 @@ impl GitStatsMethods for Database {
                 lines_added: row.get(2)?,
                 lines_removed: row.get(3)?,
                 has_uncommitted: row.get(4)?,
-                calculated_at: Utc.timestamp_opt(row.get(5)?, 0).unwrap(),
+                calculated_at: utc_from_epoch_seconds_lossy(row.get(5)?),
                 last_diff_change_ts: None,
             })
         })?;
@@ -115,7 +116,7 @@ impl GitStatsMethods for Database {
                 lines_added: row.get(2)?,
                 lines_removed: row.get(3)?,
                 has_uncommitted: row.get(4)?,
-                calculated_at: Utc.timestamp_opt(row.get(5)?, 0).unwrap(),
+                calculated_at: utc_from_epoch_seconds_lossy(row.get(5)?),
                 last_diff_change_ts: None,
             })
         })?;

--- a/src-tauri/src/infrastructure/database/db_archived_specs.rs
+++ b/src-tauri/src/infrastructure/database/db_archived_specs.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
 use rusqlite::params;
 use std::path::{Path, PathBuf};
 
 use crate::domains::sessions::entity::ArchivedSpec;
+use crate::infrastructure::database::timestamps::utc_from_epoch_millis_lossy;
 use crate::schaltwerk_core::database::Database;
 
 pub trait ArchivedSpecMethods {
@@ -49,7 +49,7 @@ impl ArchivedSpecMethods for Database {
                 content: row.get(4)?,
                 archived_at: {
                     let ms: i64 = row.get(5)?;
-                    Utc.timestamp_millis_opt(ms).unwrap()
+                    utc_from_epoch_millis_lossy(ms)
                 },
             })
         })?;

--- a/src-tauri/src/infrastructure/database/db_specs.rs
+++ b/src-tauri/src/infrastructure/database/db_specs.rs
@@ -1,7 +1,8 @@
 use super::connection::Database;
 use crate::domains::sessions::entity::Spec;
+use crate::infrastructure::database::timestamps::utc_from_epoch_seconds_lossy;
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
+use chrono::Utc;
 use rusqlite::{Row, params};
 use std::path::{Path, PathBuf};
 
@@ -141,11 +142,11 @@ fn row_to_spec(row: &Row<'_>) -> rusqlite::Result<Spec> {
         content: row.get(6)?,
         created_at: {
             let ts: i64 = row.get(7)?;
-            Utc.timestamp_opt(ts, 0).unwrap()
+            utc_from_epoch_seconds_lossy(ts)
         },
         updated_at: {
             let ts: i64 = row.get(8)?;
-            Utc.timestamp_opt(ts, 0).unwrap()
+            utc_from_epoch_seconds_lossy(ts)
         },
     })
 }

--- a/src-tauri/src/infrastructure/database/mod.rs
+++ b/src-tauri/src/infrastructure/database/mod.rs
@@ -5,6 +5,7 @@ pub mod db_epics;
 pub mod db_project_config;
 pub mod db_schema;
 pub mod db_specs;
+pub mod timestamps;
 
 pub use connection::Database;
 pub use db_app_config::AppConfigMethods;

--- a/src-tauri/src/infrastructure/database/timestamps.rs
+++ b/src-tauri/src/infrastructure/database/timestamps.rs
@@ -1,0 +1,60 @@
+use chrono::{DateTime, TimeZone, Utc};
+
+const MILLIS_THRESHOLD: i64 = 10_000_000_000;
+
+fn utc_epoch() -> DateTime<Utc> {
+    Utc.timestamp_opt(0, 0).single().unwrap_or_else(Utc::now)
+}
+
+pub fn utc_from_epoch_seconds_lossy(ts: i64) -> DateTime<Utc> {
+    if ts.abs() >= MILLIS_THRESHOLD
+        && let Some(dt) = Utc.timestamp_opt(ts / 1000, 0).single()
+    {
+        log::warn!("Coerced milliseconds timestamp to seconds (ts={ts})");
+        return dt;
+    }
+
+    if let Some(dt) = Utc.timestamp_opt(ts, 0).single() {
+        return dt;
+    }
+
+    log::warn!("Invalid epoch seconds timestamp (ts={ts}); falling back to epoch");
+    utc_epoch()
+}
+
+pub fn utc_from_epoch_seconds_lossy_opt(ts: Option<i64>) -> Option<DateTime<Utc>> {
+    let ts = ts?;
+
+    if ts.abs() >= MILLIS_THRESHOLD
+        && let Some(dt) = Utc.timestamp_opt(ts / 1000, 0).single()
+    {
+        log::warn!("Coerced milliseconds timestamp to seconds (ts={ts})");
+        return Some(dt);
+    }
+
+    if let Some(dt) = Utc.timestamp_opt(ts, 0).single() {
+        return Some(dt);
+    }
+
+    log::warn!("Invalid epoch seconds timestamp (ts={ts}); treating as missing");
+    None
+}
+
+pub fn utc_from_epoch_millis_lossy(ms: i64) -> DateTime<Utc> {
+    let candidate = if ms.abs() < MILLIS_THRESHOLD { ms * 1000 } else { ms };
+
+    if let Some(dt) = Utc.timestamp_millis_opt(candidate).single() {
+        if candidate != ms {
+            log::warn!("Coerced seconds timestamp to millis (ms={ms})");
+        }
+        return dt;
+    }
+
+    if let Some(dt) = Utc.timestamp_opt(ms, 0).single() {
+        log::warn!("Coerced seconds timestamp to millis via seconds parse (ms={ms})");
+        return dt;
+    }
+
+    log::warn!("Invalid epoch millis timestamp (ms={ms}); falling back to epoch");
+    utc_epoch()
+}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -2036,7 +2036,7 @@ fi`}
                                 <span className="text-body text-slate-300">Enable GPU-accelerated rendering (WebGL)</span>
                             </label>
                             <div className="mt-2 text-caption text-slate-500">
-                                Uses hardware acceleration for better performance with multiple terminals. Automatically falls back to Canvas if WebGL is unavailable.
+                                Uses hardware acceleration for better performance with multiple terminals. Automatically falls back to the DOM renderer if WebGL is unavailable.
                             </div>
                         </div>
 

--- a/src/components/specs/MarkdownEditor.test.tsx
+++ b/src/components/specs/MarkdownEditor.test.tsx
@@ -67,6 +67,10 @@ describe('MarkdownEditor', () => {
     const withProviderExtensions = captureExtensions({ fileReferenceProvider: provider })
 
     expect(withProviderExtensions.length).toBe(baseExtensions.length + 1)
+
+    const lastExtension = withProviderExtensions[withProviderExtensions.length - 1]
+    expect(Array.isArray(lastExtension)).toBe(true)
+    expect((lastExtension as Extension[]).length).toBe(2)
   })
 
   it('blocks oversized paste operations and reports through toast', () => {

--- a/src/components/specs/fileReferenceAutocomplete.ts
+++ b/src/components/specs/fileReferenceAutocomplete.ts
@@ -1,7 +1,8 @@
-import { autocompletion, type Completion, type CompletionContext } from '@codemirror/autocomplete'
-import type { Extension } from '@codemirror/state'
+import { acceptCompletion, autocompletion, type Completion, type CompletionContext } from '@codemirror/autocomplete'
+import { Prec, type Extension } from '@codemirror/state'
 import type { ProjectFileIndexApi } from '../../hooks/useProjectFileIndex'
 import { logger } from '../../utils/logger'
+import { keymap } from '@codemirror/view'
 
 const FILE_COMPLETION_PATTERN = /@[A-Za-z0-9_./-]*/
 const MAX_COMPLETION_RESULTS = 40
@@ -71,10 +72,18 @@ export function createFileReferenceAutocomplete(provider: ProjectFileIndexApi): 
     }
   }
 
-  return autocompletion({
-    override: [completionSource],
-    closeOnBlur: true,
-  })
+  return [
+    autocompletion({
+      override: [completionSource],
+      closeOnBlur: true,
+    }),
+    Prec.high(
+      keymap.of([
+        { key: 'Enter', run: acceptCompletion },
+        { key: 'Tab', run: acceptCompletion },
+      ])
+    ),
+  ]
 }
 
 export function filterFilePaths(files: string[], query: string): string[] {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -37,13 +37,13 @@ import { writeTerminalBackend } from '../../terminal/transport/backend'
 import { buildBracketedPasteChunks } from '../../terminal/paste/bracketedPaste'
 import {
     acquireTerminalInstance,
+    attachTerminalInstance,
     detachTerminalInstance,
     hasTerminalInstance,
     isTerminalBracketedPasteEnabled,
 } from '../../terminal/registry/terminalRegistry'
 import { XtermTerminal } from '../../terminal/xterm/XtermTerminal'
 import { useTerminalGpu } from '../../hooks/useTerminalGpu'
-import { terminalOutputManager } from '../../terminal/stream/terminalOutputManager'
 import { TerminalResizeCoordinator } from './resize/TerminalResizeCoordinator'
 import {
     calculateEffectiveColumns,
@@ -139,6 +139,7 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     }, []);
     const termRef = useRef<HTMLDivElement>(null);
     const lastMeasuredDimensionsRef = useRef<{ width: number; height: number }>({ width: 0, height: 0 });
+    const layoutSuspendedRef = useRef(false);
     const readDimensions = useCallback(() => {
         const el = termRef.current;
         if (!el || !el.isConnected) {
@@ -159,6 +160,35 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     const xtermWrapperRef = useRef<XtermTerminal | null>(null);
     const fileLinkHandlerRef = useRef<TerminalFileLinkHandler | null>(null);
     const scrollDebugRef = useRef<{ lastY: number; lastTime: number; changes: number[] }>({ lastY: -1, lastTime: 0, changes: [] });
+    const debugCountersRef = useRef<{ scrollEvents: number; initRuns: number }>({ scrollEvents: 0, initRuns: 0 });
+    const termDebug = () => (typeof window !== 'undefined' && localStorage.getItem('TERMINAL_DEBUG') === '1');
+
+    const getScrollSnapshot = useCallback(() => {
+        const term = terminal.current;
+        const el = termRef.current;
+        if (!term) return null;
+        try {
+            const buf = term.buffer?.active;
+            return {
+                cols: term.cols,
+                rows: term.rows,
+                bufferType: (buf as unknown as { type?: string })?.type,
+                baseY: buf?.baseY,
+                viewportY: buf?.viewportY,
+                cursorY: (buf as unknown as { cursorY?: number })?.cursorY,
+                length: buf?.length,
+                container: el ? { w: el.clientWidth, h: el.clientHeight } : undefined,
+            };
+        } catch (error) {
+            return { error: String(error) };
+        }
+    }, []);
+
+    const logScrollSnapshot = useCallback((source: string, extra?: Record<string, unknown>) => {
+        if (!termDebug()) return;
+        const snap = getScrollSnapshot();
+        logger.debug(`[Terminal ${terminalId}] [scroll-snap] ${source}`, { ...extra, ...snap });
+    }, [getScrollSnapshot, terminalId]);
     const logScrollChange = useCallback((source: string) => {
         const term = terminal.current;
         if (!term) return;
@@ -168,6 +198,8 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
         const debug = scrollDebugRef.current;
         const delta = debug.lastY >= 0 ? viewportY - debug.lastY : 0;
         const timeDelta = debug.lastTime > 0 ? now - debug.lastTime : 0;
+        debugCountersRef.current.scrollEvents += 1;
+        const debugEnabled = termDebug();
         if (Math.abs(delta) > 0 && timeDelta < 500) {
             debug.changes.push(delta);
             if (debug.changes.length > 10) debug.changes.shift();
@@ -175,13 +207,17 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
                 debug.changes.slice(-4).some((d, i, arr) => i > 0 && Math.sign(d) !== Math.sign(arr[i-1]));
             if (hasOscillation) {
                 logger.warn(`[Terminal ${terminalId}] OSCILLATION DETECTED source=${source} viewportY=${viewportY} baseY=${baseY} delta=${delta} timeDelta=${timeDelta.toFixed(0)}ms changes=[${debug.changes.join(',')}]`);
+                logScrollSnapshot(`${source}:oscillation`, { delta, timeDelta });
             } else if (Math.abs(delta) > 5) {
                 logger.debug(`[Terminal ${terminalId}] Scroll jump source=${source} viewportY=${viewportY} baseY=${baseY} delta=${delta} timeDelta=${timeDelta.toFixed(0)}ms`);
+                logScrollSnapshot(`${source}:jump`, { delta, timeDelta });
+            } else if (debugEnabled && (debugCountersRef.current.scrollEvents % 25 === 0)) {
+                logScrollSnapshot(`${source}:periodic`, { delta, timeDelta });
             }
         }
         debug.lastY = viewportY;
         debug.lastTime = now;
-    }, [terminalId]);
+    }, [terminalId, logScrollSnapshot]);
     const getPreviewState = useAtomValue(previewStateAtom)
     const setPreviewUrl = useSetAtom(setPreviewUrlActionAtom)
     const previewWatcherRef = useRef<LocalPreviewWatcher | null>(null)
@@ -325,7 +361,6 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
         setIsSearchVisible(false);
         setSearchTerm('');
     }, []);
-    const termDebug = () => (typeof window !== 'undefined' && localStorage.getItem('TERMINAL_DEBUG') === '1');
     const terminalIdRef = useRef(terminalId);
     terminalIdRef.current = terminalId;
     const sessionScopeRef = useRef<string | null>(null);
@@ -334,7 +369,7 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     const mountedRef = useRef<boolean>(false);
     const startingTerminals = useRef<Map<string, boolean>>(new Map());
     const previousTerminalId = useRef<string>(terminalId);
-    const rendererReadyRef = useRef<boolean>(false); // Canvas renderer readiness flag
+    const rendererReadyRef = useRef<boolean>(false); // Renderer readiness flag
     const [fontsFullyLoaded, setFontsFullyLoaded] = useState(false);
     const fontsLoadedRef = useRef(false);
     const agentTypeRef = useRef(agentType);
@@ -426,44 +461,34 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
 
     const applySizeUpdate = useCallback((cols: number, rows: number, reason: string, _force = false) => {
         if (!terminal.current) return false;
-        if (cols < MIN_TERMINAL_COLUMNS || rows < MIN_TERMINAL_ROWS) {
-            logger.debug(`[Terminal ${terminalId}] Skipping ${reason} resize due to tiny dimensions ${cols}x${rows}`);
-            const prevCols = lastSize.current.cols;
-            const prevRows = lastSize.current.rows;
-            if (prevCols >= MIN_TERMINAL_COLUMNS && prevRows >= MIN_TERMINAL_ROWS) {
-                requestAnimationFrame(() => {
-                    try {
-                        terminal.current?.resize(prevCols, prevRows);
-                    } catch (error) {
-                        logger.debug(`[Terminal ${terminalId}] Failed to restore previous size after tiny resize`, error);
-                    }
-                });
-            }
-            return false;
-        }
-
         const effectiveCols = calculateEffectiveColumns(cols);
-        lastSize.current = { cols, rows };
+        const effectiveRows = Math.max(Math.floor(rows), MIN_TERMINAL_ROWS);
+        if (effectiveCols !== cols || effectiveRows !== rows) {
+            logger.debug(`[Terminal ${terminalId}] Clamping ${reason} resize ${cols}x${rows} → ${effectiveCols}x${effectiveRows}`);
+        }
+        lastSize.current = { cols: effectiveCols, rows: effectiveRows };
 
         const term = terminal.current;
         try {
-            term.resize(effectiveCols, rows);
+            logScrollSnapshot(`resize:${reason}:before`, { cols: effectiveCols, rows: effectiveRows });
+            term.resize(effectiveCols, effectiveRows);
             if (xtermWrapperRef.current?.shouldFollowOutput()) {
                 requestAnimationFrame(() => {
                     term.scrollToLine(term.buffer.active.baseY);
                     logScrollChange('applySizeUpdate');
                 });
             }
+            logScrollSnapshot(`resize:${reason}:after`, { cols: effectiveCols, rows: effectiveRows });
         } catch (e) {
-            logger.debug(`[Terminal ${terminalId}] Failed to apply frontend resize to ${effectiveCols}x${rows}`, e);
+            logger.debug(`[Terminal ${terminalId}] Failed to apply frontend resize to ${effectiveCols}x${effectiveRows}`, e);
         }
 
-        recordTerminalSize(terminalId, effectiveCols, rows);
-        schedulePtyResize(terminalId, { cols: effectiveCols, rows });
-        lastEffectiveRef.current = { cols: effectiveCols, rows };
+        recordTerminalSize(terminalId, effectiveCols, effectiveRows);
+        schedulePtyResize(terminalId, { cols: effectiveCols, rows: effectiveRows });
+        lastEffectiveRef.current = { cols: effectiveCols, rows: effectiveRows };
         rememberDimensions();
         return true;
-    }, [terminalId, rememberDimensions, logScrollChange]);
+    }, [terminalId, rememberDimensions, logScrollChange, logScrollSnapshot]);
 
     useEffect(() => {
         const coordinator = new TerminalResizeCoordinator({
@@ -492,10 +517,10 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
             applyRowsOnly: (rows, _context) => {
                 if (!terminal.current) return;
                 const currentCols = terminal.current.cols;
-                if (rows < MIN_TERMINAL_ROWS) return;
+                const effectiveRows = Math.max(Math.floor(rows), MIN_TERMINAL_ROWS);
                 const term = terminal.current;
                 try {
-                    term.resize(currentCols, rows);
+                    term.resize(currentCols, effectiveRows);
                     if (xtermWrapperRef.current?.shouldFollowOutput()) {
                         requestAnimationFrame(() => {
                             term.scrollToLine(term.buffer.active.baseY);
@@ -503,18 +528,17 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
                         });
                     }
                 } catch (e) {
-                    logger.debug(`[Terminal ${terminalId}] Failed to apply rows-only resize to ${currentCols}x${rows}`, e);
+                    logger.debug(`[Terminal ${terminalId}] Failed to apply rows-only resize to ${currentCols}x${effectiveRows}`, e);
                 }
-                lastSize.current = { cols: currentCols, rows };
-                recordTerminalSize(terminalId, currentCols, rows);
-                schedulePtyResize(terminalId, { cols: currentCols, rows });
-                lastEffectiveRef.current = { cols: currentCols, rows };
+                lastSize.current = { cols: currentCols, rows: effectiveRows };
+                recordTerminalSize(terminalId, currentCols, effectiveRows);
+                schedulePtyResize(terminalId, { cols: currentCols, rows: effectiveRows });
+                lastEffectiveRef.current = { cols: currentCols, rows: effectiveRows };
             },
             applyColsOnly: (cols, _context) => {
                 if (!terminal.current) return;
                 const currentRows = terminal.current.rows;
                 const effectiveCols = calculateEffectiveColumns(cols);
-                if (effectiveCols < MIN_TERMINAL_COLUMNS) return;
                 const term = terminal.current;
                 try {
                     term.resize(effectiveCols, currentRows);
@@ -615,16 +639,29 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
             return;
         }
 
+        const wasSuspended = layoutSuspendedRef.current;
         if (isMeasurementTooSmall(measured.width, measured.height)) {
-            logger.debug(`[Terminal ${terminalId}] Skipping ${reason} resize - container too small (${measured.width}x${measured.height})`);
+            lastMeasuredDimensionsRef.current = measured;
+            layoutSuspendedRef.current = true;
+            if (!wasSuspended) {
+                logger.debug(`[Terminal ${terminalId}] Suspending resize - container too small (${measured.width}x${measured.height})`);
+            }
             return;
         }
 
-        if (!options?.force) {
+        if (wasSuspended) {
+            layoutSuspendedRef.current = false;
+            logger.debug(`[Terminal ${terminalId}] Resuming resize - container measurable (${measured.width}x${measured.height})`);
+        }
+
+        const shouldForce = Boolean(options?.force) || wasSuspended;
+        const shouldImmediate = Boolean(options?.immediate) || wasSuspended;
+
+        if (!shouldForce) {
             const prev = lastMeasuredDimensionsRef.current;
             const deltaWidth = Math.abs(measured.width - prev.width);
             const deltaHeight = Math.abs(measured.height - prev.height);
-            if (!options?.immediate && deltaWidth < RESIZE_PIXEL_EPSILON && deltaHeight < RESIZE_PIXEL_EPSILON) {
+            if (!shouldImmediate && deltaWidth < RESIZE_PIXEL_EPSILON && deltaHeight < RESIZE_PIXEL_EPSILON) {
                 return;
             }
         }
@@ -633,19 +670,27 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
         const proposer = fitAddon.current as unknown as { proposeDimensions?: () => { cols: number; rows: number } | undefined };
         const proposed = proposer.proposeDimensions?.();
         if (!proposed || !Number.isFinite(proposed.cols) || !Number.isFinite(proposed.rows) || proposed.cols <= 0 || proposed.rows <= 0) {
+            layoutSuspendedRef.current = true;
+            logger.debug(`[Terminal ${terminalId}] Suspending resize - invalid size proposal`, { proposed, reason });
             return;
         }
 
         if (proposed.cols < MIN_PROPOSED_COLUMNS) {
-            logger.debug(`[Terminal ${terminalId}] Skipping ${reason} resize - proposed columns too small (${proposed.cols})`);
+            logger.debug(`[Terminal ${terminalId}] Clamping ${reason} resize - proposed columns too small (${proposed.cols})`);
+            resizeCoordinatorRef.current?.resize({
+                cols: MIN_TERMINAL_COLUMNS,
+                rows: Math.max(MIN_TERMINAL_ROWS, proposed.rows),
+                reason: `${reason}:min-clamp-proposal`,
+                immediate: true,
+            });
             return;
         }
 
         resizeCoordinatorRef.current?.resize({
-            cols: proposed.cols,
-            rows: proposed.rows,
+            cols: Math.max(MIN_TERMINAL_COLUMNS, proposed.cols),
+            rows: Math.max(MIN_TERMINAL_ROWS, proposed.rows),
             reason,
-            immediate: options?.immediate ?? false,
+            immediate: shouldImmediate,
         });
     }, [readDimensions, terminalId]);
 
@@ -1106,6 +1151,10 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     }, [agentType, terminalId]);
 
     useEffect(() => {
+        debugCountersRef.current.initRuns += 1;
+        if (termDebug()) {
+            logger.debug(`[Terminal ${terminalId}] [init] effect run #${debugCountersRef.current.initRuns}`);
+        }
         mountedRef.current = true;
         let cancelled = false;
         // track mounted lifecycle only; no timer-based logic tied to mount time
@@ -1149,8 +1198,9 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
         searchAddon.current = instance.searchAddon;
         
         if (termRef.current) {
-            instance.attach(termRef.current);
+            attachTerminalInstance(terminalId, termRef.current);
         }
+        logScrollSnapshot('attached');
         applyLetterSpacingRef.current?.(webglRendererActiveRef.current);
         // Allow streaming immediately; proper fits will still run later
         rendererReadyRef.current = true;
@@ -1393,11 +1443,17 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
                 const disposable = renderHandler.call(terminal.current, () => {
                     if (!hydratedRef.current) {
                         hydratedRef.current = true;
-                        setHydrated(true);
-                        if (!hydratedOnceRef.current) {
-                            hydratedOnceRef.current = true;
-                            onReadyRef.current?.();
-                        }
+	                        setHydrated(true);
+	                        if (!hydratedOnceRef.current) {
+	                            hydratedOnceRef.current = true;
+	                            try {
+	                                emitUiEvent(UiEvent.TerminalReady, { terminalId });
+	                            } catch (error) {
+	                                logger.debug(`[Terminal ${terminalId}] Failed to emit terminal-ready event`, error);
+	                            }
+	                            onReadyRef.current?.();
+	                        }
+                        logScrollSnapshot('onRender:hydrated');
                     }
                 });
                 if (disposable && typeof disposable === 'object' && typeof (disposable as { dispose?: () => void }).dispose === 'function') {
@@ -1405,10 +1461,6 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
                 }
             }
         }
-
-        void terminalOutputManager.ensureStarted(terminalId).catch(error => {
-            logger.warn(`[Terminal ${terminalId}] Failed to ensure terminal stream`, error);
-        });
 
         // Handle font size changes with better debouncing
         let fontSizeRafPending = false;
@@ -1610,6 +1662,7 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
             mountedRef.current = false;
             cancelled = true;
             rendererReadyRef.current = false;
+            logScrollSnapshot('cleanup:before-detach');
 
             outputDisposables.forEach(disposable => {
                 try {
@@ -1648,6 +1701,7 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
             }
 
             detachTerminalInstance(terminalId);
+            logScrollSnapshot('cleanup:after-detach');
             xtermWrapperRef.current = null;
             gpuRenderer.current = null;
             terminal.current = null;
@@ -1662,8 +1716,6 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
         terminalId,
         addEventListener,
         addResizeObserver,
-        gpuEnabledForTerminal,
-        gpuRenderer,
     ]);
 
 

--- a/src/components/terminal/TerminalTabs.tsx
+++ b/src/components/terminal/TerminalTabs.tsx
@@ -4,7 +4,7 @@ import { useTerminalTabs } from '../../hooks/useTerminalTabs'
 import { UnifiedTab } from '../UnifiedTab'
 import { theme } from '../../common/theme'
 import { useModal } from '../../contexts/ModalContext'
-import { safeTerminalFocus, safeTerminalFocusImmediate } from '../../utils/safeFocus'
+import { safeTerminalFocusImmediate } from '../../utils/safeFocus'
 import { TabInfo } from '../../types/terminalTabs'
 import { AddTabButton } from '../AddTabButton'
 import type { AutoPreviewConfig } from '../../utils/runScriptPreviewConfig'
@@ -153,15 +153,15 @@ const TerminalTabsComponent = forwardRef<TerminalTabsHandle, TerminalTabsProps>(
             id={tab.index}
             label={tab.label}
             isActive={tab.index === activeTab}
-            onSelect={() => {
-              setActiveTab(tab.index)
-              requestAnimationFrame(() => {
-                const activeTerminalRef = terminalRefs.current.get(tab.index)
-                if (activeTerminalRef) {
-                  safeTerminalFocus(() => activeTerminalRef.focus(), isAnyModalOpen)
-                }
-              })
-            }}
+	            onSelect={() => {
+	              setActiveTab(tab.index)
+	              requestAnimationFrame(() => {
+	                const activeTerminalRef = terminalRefs.current.get(tab.index)
+	                if (activeTerminalRef) {
+	                  safeTerminalFocusImmediate(() => activeTerminalRef.focus(), isAnyModalOpen)
+	                }
+	              })
+	            }}
             onClose={tabs.length > 1 ? () => { void closeTab(tab.index) } : undefined}
             onMiddleClick={tabs.length > 1 ? () => { void closeTab(tab.index) } : undefined}
             showCloseButton={tabs.length > 1}

--- a/src/hooks/__tests__/useTerminalGpu.test.ts
+++ b/src/hooks/__tests__/useTerminalGpu.test.ts
@@ -27,12 +27,12 @@ const {
   getLastRenderer,
   clearLastRenderer,
 } = vi.hoisted(() => {
-  let rendererStateType: 'canvas' | 'webgl' = 'canvas'
+  let rendererStateType: 'dom' | 'webgl' = 'dom'
   let lastRenderer: unknown = null
 
   class MockWebGLTerminalRenderer {
-    #state: { type: 'canvas' | 'webgl' | 'none'; contextLost: boolean } = {
-      type: 'canvas',
+    #state: { type: 'dom' | 'webgl' | 'none'; contextLost: boolean } = {
+      type: 'dom',
       contextLost: false,
     }
     constructor() {
@@ -41,8 +41,8 @@ const {
     ensureLoaded = vi.fn(async () => {
       if (rendererStateType === 'webgl') {
         this.#state = { type: 'webgl', contextLost: false }
-      } else if (rendererStateType === 'canvas') {
-        this.#state = { type: 'canvas', contextLost: false }
+      } else if (rendererStateType === 'dom') {
+        this.#state = { type: 'dom', contextLost: false }
       }
       return this.#state
     })
@@ -62,11 +62,11 @@ const {
 
   return {
     MockWebGLTerminalRenderer,
-    setRendererStateType: (type: 'canvas' | 'webgl') => {
+    setRendererStateType: (type: 'dom' | 'webgl') => {
       rendererStateType = type
     },
     resetRendererStateType: () => {
-      rendererStateType = 'canvas'
+      rendererStateType = 'dom'
     },
     getLastRenderer: () => lastRenderer as MockWebGLTerminalRenderer | null,
     clearLastRenderer: () => {

--- a/src/hooks/useAgentTabs.ts
+++ b/src/hooks/useAgentTabs.ts
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai'
-import { useCallback } from 'react'
+import { useCallback, useLayoutEffect } from 'react'
 import {
     agentTabsStateAtom,
     AgentTab,
@@ -17,6 +17,7 @@ import {
     clearActiveAgentTerminalId,
     resolveActiveAgentTerminalId,
     setActiveAgentTerminalId,
+    setActiveAgentTerminalFromTabsState,
 } from '../common/terminalTargeting'
 
 type StartAgentFn = (params: {
@@ -32,6 +33,11 @@ export const useAgentTabs = (
 ) => {
     const [agentTabsMap, setAgentTabsMap] = useAtom(agentTabsStateAtom)
     const startAgent = options?.startAgent
+
+    useLayoutEffect(() => {
+        if (!sessionId || !baseTerminalId) return
+        setActiveAgentTerminalFromTabsState(sessionId, agentTabsMap.get(sessionId) ?? null, baseTerminalId)
+    }, [agentTabsMap, sessionId, baseTerminalId])
 
     const parseTabNumericIndex = useCallback((tab: AgentTab, fallback: number): number => {
         if (tab.id.startsWith('tab-')) {

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -15,7 +15,9 @@ import { isTuiAgent } from '../types/session'
 const DEFAULT_SCROLLBACK_LINES = 10000
 const BACKGROUND_SCROLLBACK_LINES = 5000
 const AGENT_SCROLLBACK_LINES = 20000
-const TUI_SCROLLBACK_LINES = 10000
+// TUI agents continuously redraw the screen and don't need scrollback; keeping scrollback causes
+// baseY/viewportY churn (especially across resizes) and can trigger flicker/scroll loops.
+const TUI_SCROLLBACK_LINES = 0
 const ATLAS_CONTRAST_BASE = 1.1
 const DEFAULT_FONT_FAMILY = 'Menlo, Monaco, ui-monospace, SFMono-Regular, monospace'
 

--- a/src/hooks/useTerminalGpu.ts
+++ b/src/hooks/useTerminalGpu.ts
@@ -52,7 +52,7 @@ export function useTerminalGpu({
     queued: false,
     redrawId: null,
   });
-  const lastRendererTypeRef = useRef<'none' | 'canvas' | 'webgl'>('none');
+  const lastRendererTypeRef = useRef<'none' | 'dom' | 'webgl'>('none');
   const [webglEnabled, setWebglEnabled] = useState<boolean>(true);
   const [webglRendererActive, setWebglRendererActive] = useState<boolean>(false);
   const letterSpacingIssueLogged = useRef<'missing' | 'failure' | null>(null);

--- a/src/index.css
+++ b/src/index.css
@@ -248,6 +248,7 @@ body.is-split-dragging [class*="transition-"] {
 .xterm-viewport {
   color-scheme: dark;
   scrollbar-gutter: stable both-edges;
+  overflow-anchor: none;
 }
 
 .xterm-viewport {

--- a/src/terminal/gpu/webglRenderer.ts
+++ b/src/terminal/gpu/webglRenderer.ts
@@ -6,7 +6,7 @@ import { markWebglFailedGlobally } from './gpuFallbackState';
 import { XtermAddonImporter } from '../xterm/xtermAddonImporter';
 
 export interface RendererState {
-    type: 'webgl' | 'canvas' | 'none';
+    type: 'webgl' | 'dom' | 'none';
     addon?: WebglAddon;
     contextLost: boolean;
 }
@@ -56,9 +56,9 @@ export class WebGLTerminalRenderer {
         this.initAttempted = true;
 
         if (!isWebGLSupported()) {
-            logger.info(`[GPU] WebGL not supported for terminal ${this.terminalId}, using canvas renderer`);
+            logger.info(`[GPU] WebGL not supported for terminal ${this.terminalId}, using DOM renderer`);
             markWebglFailedGlobally('unsupported');
-            this.state = { type: 'canvas', contextLost: false };
+            this.state = { type: 'dom', contextLost: false };
             this.initializing = false;
             return this.state;
         }
@@ -90,7 +90,7 @@ export class WebGLTerminalRenderer {
                 error
             );
             markWebglFailedGlobally('initialization-failed');
-            this.state = { type: 'canvas', contextLost: false };
+            this.state = { type: 'dom', contextLost: false };
             return this.state;
         } finally {
             this.initializing = false;

--- a/src/terminal/xterm/XtermTerminal.ts
+++ b/src/terminal/xterm/XtermTerminal.ts
@@ -264,6 +264,12 @@ export class XtermTerminal {
     }
 
     try {
+      this.raw.options.scrollOnUserInput = false
+    } catch (error) {
+      logger.debug(`[XtermTerminal ${this.terminalId}] Failed to disable scrollOnUserInput for TUI mode`, error)
+    }
+
+    try {
       this.raw.write('\x1b[?25l')
     } catch (error) {
       logger.debug(`[XtermTerminal ${this.terminalId}] Failed to hide cursor for TUI mode`, error)
@@ -275,6 +281,12 @@ export class XtermTerminal {
       this.raw.options.cursorBlink = true
     } catch (error) {
       logger.debug(`[XtermTerminal ${this.terminalId}] Failed to enable cursor blink for standard mode`, error)
+    }
+
+    try {
+      this.raw.options.scrollOnUserInput = true
+    } catch (error) {
+      logger.debug(`[XtermTerminal ${this.terminalId}] Failed to enable scrollOnUserInput for standard mode`, error)
     }
 
     try {
@@ -451,16 +463,22 @@ export class XtermTerminal {
     try {
       this.raw.parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
         if (params.length > 0 && params[0] === SYNC_MODE) {
-          logger.debug(`[XtermTerminal ${this.terminalId}] Synchronized output enabled`)
-          return true
+          if (typeof window !== 'undefined' && localStorage.getItem('TERMINAL_DEBUG') === '1') {
+            logger.debug(`[XtermTerminal ${this.terminalId}] Synchronized output enabled`)
+          }
+          // Allow xterm.js to handle the mode switch (prevents visible tearing/flicker for TUIs).
+          return false
         }
         return false
       })
 
       this.raw.parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
         if (params.length > 0 && params[0] === SYNC_MODE) {
-          logger.debug(`[XtermTerminal ${this.terminalId}] Synchronized output disabled`)
-          return true
+          if (typeof window !== 'undefined' && localStorage.getItem('TERMINAL_DEBUG') === '1') {
+            logger.debug(`[XtermTerminal ${this.terminalId}] Synchronized output disabled`)
+          }
+          // Allow xterm.js to handle the mode switch (prevents visible tearing/flicker for TUIs).
+          return false
         }
         return false
       })

--- a/src/utils/errorMessage.test.ts
+++ b/src/utils/errorMessage.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { extractErrorMessage } from './errorMessage'
+
+describe('extractErrorMessage', () => {
+  it('returns message from Error instance', () => {
+    const error = new Error('Something went wrong')
+    expect(extractErrorMessage(error)).toBe('Something went wrong')
+  })
+
+  it('returns string directly when error is a string', () => {
+    expect(extractErrorMessage('gh command failed')).toBe('gh command failed')
+  })
+
+  it('returns message property from object with message', () => {
+    const error = { message: 'Custom error message' }
+    expect(extractErrorMessage(error)).toBe('Custom error message')
+  })
+
+  it('returns fallback for undefined', () => {
+    expect(extractErrorMessage(undefined)).toBe('An unknown error occurred')
+  })
+
+  it('returns fallback for null', () => {
+    expect(extractErrorMessage(null)).toBe('An unknown error occurred')
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(extractErrorMessage('')).toBe('An unknown error occurred')
+  })
+
+  it('returns fallback for whitespace-only string', () => {
+    expect(extractErrorMessage('   ')).toBe('An unknown error occurred')
+  })
+
+  it('returns fallback for object without message property', () => {
+    const error = { code: 1, stderr: 'error output' }
+    expect(extractErrorMessage(error)).toBe('An unknown error occurred')
+  })
+
+  it('handles Error with empty message', () => {
+    const error = new Error('')
+    expect(extractErrorMessage(error)).toBe('An unknown error occurred')
+  })
+
+  it('trims whitespace from messages', () => {
+    expect(extractErrorMessage('  error message  ')).toBe('error message')
+  })
+
+  it('handles number values', () => {
+    expect(extractErrorMessage(42)).toBe('An unknown error occurred')
+  })
+
+  it('handles boolean values', () => {
+    expect(extractErrorMessage(true)).toBe('An unknown error occurred')
+    expect(extractErrorMessage(false)).toBe('An unknown error occurred')
+  })
+
+  it('supports custom fallback message', () => {
+    expect(extractErrorMessage(undefined, 'Custom fallback')).toBe('Custom fallback')
+    expect(extractErrorMessage(null, 'Custom fallback')).toBe('Custom fallback')
+    expect(extractErrorMessage('', 'Custom fallback')).toBe('Custom fallback')
+  })
+
+  it('returns error property if message is not present but error is', () => {
+    const error = { error: 'Error from API' }
+    expect(extractErrorMessage(error)).toBe('Error from API')
+  })
+
+  it('prefers message over error property', () => {
+    const error = { message: 'Message', error: 'Error' }
+    expect(extractErrorMessage(error)).toBe('Message')
+  })
+})

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,0 +1,30 @@
+const DEFAULT_FALLBACK = 'An unknown error occurred'
+
+export function extractErrorMessage(error: unknown, fallback: string = DEFAULT_FALLBACK): string {
+  if (error instanceof Error) {
+    const message = error.message?.trim()
+    return message || fallback
+  }
+
+  if (typeof error === 'string') {
+    const message = error.trim()
+    return message || fallback
+  }
+
+  if (error && typeof error === 'object') {
+    if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+      const message = ((error as { message: string }).message).trim()
+      if (message) {
+        return message
+      }
+    }
+    if ('error' in error && typeof (error as { error?: unknown }).error === 'string') {
+      const message = ((error as { error: string }).error).trim()
+      if (message) {
+        return message
+      }
+    }
+  }
+
+  return fallback
+}


### PR DESCRIPTION
Fixes #204.

- Prefer real Codex `session_meta` ids when extracting from `.codex/sessions/*.jsonl`.
- Ignore non-session command tokens like `exec`/`resume` to avoid launching `codex resume exec`.
- Add regression test covering the mixed-record ordering case.