### PR TITLE
feat: Add multiple orchestrator tabs support (#223)

### DIFF
--- a/src-tauri/src/commands/schaltwerk_core.rs
+++ b/src-tauri/src/commands/schaltwerk_core.rs
@@ -1878,8 +1878,10 @@ pub async fn schaltwerk_core_start_claude_orchestrator(
     terminal_id: String,
     cols: Option<u16>,
     rows: Option<u16>,
+    agent_type: Option<String>,
 ) -> Result<String, String> {
-    log::info!("[AGENT_LAUNCH_TRACE] Starting Claude for orchestrator in terminal: {terminal_id}");
+    let agent_label = agent_type.as_deref().unwrap_or("claude");
+    log::info!("[AGENT_LAUNCH_TRACE] Starting {agent_label} for orchestrator in terminal: {terminal_id}");
 
     log::info!("[AGENT_LAUNCH_TRACE] Acquiring core read lock for {terminal_id}");
     let core = match get_core_read().await {
@@ -1929,10 +1931,10 @@ pub async fn schaltwerk_core_start_claude_orchestrator(
     };
 
     let command_spec = manager
-        .start_claude_in_orchestrator_with_binary(&binary_paths)
+        .start_agent_in_orchestrator(&binary_paths, agent_type.as_deref())
         .map_err(|e| {
             log::error!("Failed to build orchestrator command: {e}");
-            format!("Failed to start Claude in orchestrator: {e}")
+            format!("Failed to start {agent_label} in orchestrator: {e}")
         })?;
 
     drop(core);

--- a/src/common/agentSpawn.ts
+++ b/src/common/agentSpawn.ts
@@ -202,12 +202,12 @@ export async function startSessionTop(params: {
 export async function startOrchestratorTop(params: {
   terminalId: string
   measured?: { cols?: number | null; rows?: number | null }
+  agentType?: string
 }) {
-  const { terminalId, measured } = params
+  const { terminalId, measured, agentType: requestedAgentType } = params
   if (hasInflight(terminalId) || isTerminalStartingOrStarted(terminalId)) return
 
-  // Orchestrator always runs Claude today; keep agentType aligned with backend expectations/metrics
-  const agentType = DEFAULT_AGENT
+  const agentType = requestedAgentType ?? DEFAULT_AGENT
   const lifecycleBase = { terminalId, agentType }
   const { cols, rows } = computeSpawnSize({ topId: terminalId, measured })
   const timeoutMs = determineStartTimeoutMs(agentType)
@@ -225,7 +225,7 @@ export async function startOrchestratorTop(params: {
     await singleflight(terminalId, async () => {
       try {
         await withAgentStartTimeout(
-          invoke(command, { terminalId, cols, rows }),
+          invoke(command, { terminalId, cols, rows, agentType: requestedAgentType }),
           timeoutMs,
           { id: terminalId, command }
         )

--- a/src/components/terminal/TerminalGrid.tsx
+++ b/src/components/terminal/TerminalGrid.tsx
@@ -134,8 +134,8 @@ const TerminalGridComponent = () => {
 
     // Agent tabs state for multiple agents in top terminal
     const agentTabScopeId = selection.kind === 'session' ? (selection.payload ?? null) : selection.kind === 'orchestrator' ? 'orchestrator' : null
-    const orchestratorTabStarter = useCallback(async ({ terminalId }: { sessionId: string; terminalId: string; agentType: string }) => {
-        await startOrchestratorTop({ terminalId })
+    const orchestratorTabStarter = useCallback(async ({ terminalId, agentType }: { sessionId: string; terminalId: string; agentType: string }) => {
+        await startOrchestratorTop({ terminalId, agentType })
     }, [])
 
     const {
@@ -862,7 +862,7 @@ const TerminalGridComponent = () => {
             // Add agent tab shortcut
             if (isShortcutForAction(event, KeyboardShortcutAction.AddAgentTab, keyboardShortcutConfig, { platform })) {
                 event.preventDefault()
-                if (selection.kind === 'session') {
+                if (selection.kind === 'session' || selection.kind === 'orchestrator') {
                     setCustomAgentModalOpen(true)
                 }
                 return
@@ -1368,8 +1368,8 @@ const TerminalGridComponent = () => {
                             tabs={agentTabsState.tabs}
                             activeTab={agentTabsState.activeTab}
                             onTabSelect={setActiveAgentTab}
-                            onTabClose={selection.kind === 'session' ? closeAgentTab : undefined}
-                            onTabAdd={selection.kind === 'session' ? () => setCustomAgentModalOpen(true) : undefined}
+                            onTabClose={(selection.kind === 'session' || selection.kind === 'orchestrator') && agentTabsState.tabs.length > 1 ? closeAgentTab : undefined}
+                            onTabAdd={(selection.kind === 'session' || selection.kind === 'orchestrator') ? () => setCustomAgentModalOpen(true) : undefined}
                             onReset={selection.kind === 'session' ? () => setConfirmResetOpen(true) : undefined}
                             isFocused={localFocus === 'claude'}
                             actionButtons={shouldShowActionButtons ? actionButtons : []}
@@ -1700,7 +1700,7 @@ const TerminalGridComponent = () => {
                 onSwitch={handleConfigureAgentsSwitch}
             />
             <CustomAgentModal
-                open={customAgentModalOpen && selection.kind === 'session'}
+                open={customAgentModalOpen && (selection.kind === 'session' || selection.kind === 'orchestrator')}
                 onClose={() => setCustomAgentModalOpen(false)}
                 onSelect={handleCustomAgentSelect}
                 initialAgentType={agentType as AgentType}


### PR DESCRIPTION
## Summary
- Enable tab controls (add/close) for orchestrator's top terminal area
- Support different agent types per orchestrator tab (Claude, Codex, Gemini, etc.)
- Fix CustomAgentModal to open for orchestrator selection (not just sessions)
- Remove hardcoded "claude" fallback in favor of proper error propagation


Closes #223