### PR TITLE
Fix attempt for #253 deferred prompt injection

### DIFF
--- a/src-tauri/agents_manifest.toml
+++ b/src-tauri/agents_manifest.toml
@@ -9,7 +9,6 @@ binary_name = "claude"
 default_binary_path = "claude"
 auto_send_initial_command = true
 supports_resume = true
-ready_marker = ">"
 
 [agents.codex]
 id = "codex"

--- a/src-tauri/src/commands/schaltwerk_core.rs
+++ b/src-tauri/src/commands/schaltwerk_core.rs
@@ -1617,7 +1617,10 @@ async fn schaltwerk_core_start_agent_in_terminal(
     if auto_send_initial_command
         && let Some(initial) = initial_command.clone().filter(|v| !v.trim().is_empty())
     {
-        let dispatch_delay = if agent_type == "copilot" || agent_type == "kilocode" {
+        let dispatch_delay = if agent_type == "copilot"
+            || agent_type == "kilocode"
+            || agent_type == "claude"
+        {
             Some(Duration::from_millis(1500))
         } else {
             None

--- a/src-tauri/src/domains/agents/manifest.rs
+++ b/src-tauri/src/domains/agents/manifest.rs
@@ -85,13 +85,12 @@ mod tests {
         assert_eq!(claude.default_binary_path, "claude");
         assert!(
             claude.auto_send_initial_command,
-            "Claude should use deferred prompt dispatch (issue #253)"
+            "Claude should use deferred prompt dispatch with time-based delay"
         );
         assert!(claude.supports_resume);
-        assert_eq!(
-            claude.ready_marker.as_deref(),
-            Some(">"),
-            "Claude's ready marker should be '>' for deferred prompt dispatch"
+        assert!(
+            claude.ready_marker.is_none(),
+            "Claude uses time-based delay instead of ready_marker"
         );
     }
 

--- a/src-tauri/src/domains/agents/unified.rs
+++ b/src-tauri/src/domains/agents/unified.rs
@@ -469,7 +469,7 @@ mod tests {
             assert_eq!(
                 spec.initial_command.as_deref(),
                 Some("/commit \"fix bug\""),
-                "Prompt should be queued via initial_command for deferred dispatch after ready_marker"
+                "Prompt should be queued via initial_command for deferred dispatch"
             );
         }
 


### PR DESCRIPTION
## Summary
Claude's prompt is not embedded in the shell command. Instead, it's queue via `initial_command`. After 1.5 seconds, the prompt is dispatched to the terminal (like Kilo and Copilot).

## Test Plan
- [x] Ran `just test` (all checks pass)
- [x] Tested manually:
  - Started agent on the UI invoking a slash command `/greet foo`
  - Started agent on the UI invoking a skill `/test-skill foo`
  - Started agent using REST API with curl

```shell
curl -X POST http://127.0.0.1:8547/api/sessions \
    -H "Content-Type: application/json" \
    -d '{
      "name": "test-issue-123",
      "prompt": "/test-skill \"test fix\"",
      "agent_type": "claude",
      "skip_permissions": true
    }'
```

## Checklist
- [x] TypeScript lint passes
- [x] Rust clippy passes
- [x] Tests pass
- [x] Build succeeds
