### PR TITLE
fix(ci): remove target-cpu=native to prevent SIGILL on runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed
     if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    env:
+      # Override target-cpu=native from .cargo/config.toml - CI runners have varying CPU features
+      # which can cause SIGILL crashes with native CPU targeting
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

CI has been failing with SIGILL (illegal instruction) crashes in the Rust compiler since Jan 23rd. This happens because `.cargo/config.toml` sets `-C target-cpu=native` for Linux builds, but GitHub Actions runners have varying CPU features.

When the runner's CPU doesn't support all instructions that `target-cpu=native` enables (based on the build environment), the compiled code crashes with SIGILL.

## Solution

Override `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS` in CI to use the mold linker but skip `target-cpu=native`.

This keeps the fast mold linker for CI builds while ensuring compatibility across different runner CPUs.

## Notes

- Local builds still use `target-cpu=native` for optimal performance
- Only CI builds are affected by this change