### PR TITLE
fix(diff): scroll to correct file when opening inline diff

### DIFF
--- a/src/components/diff/UnifiedDiffView.tsx
+++ b/src/components/diff/UnifiedDiffView.tsx
@@ -1239,8 +1239,12 @@ export function UnifiedDiffView({
 
   const prevFilePathForScrollRef = useRef<string | null>(filePath);
   const pendingScrollRef = useRef<string | null>(null);
+  const wasOpenRef = useRef(isOpen);
 
   useLayoutEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = isOpen;
+
     if (viewMode !== "sidebar" || !isOpen || !filePath) {
       prevFilePathForScrollRef.current = filePath;
       pendingScrollRef.current = null;
@@ -1249,7 +1253,11 @@ export function UnifiedDiffView({
     const prevPath = prevFilePathForScrollRef.current;
     prevFilePathForScrollRef.current = filePath;
 
-    if (prevPath === filePath) {
+    // Skip scroll only if both the path AND open state are unchanged.
+    // When opening for the first time (wasOpen=false -> isOpen=true),
+    // we must scroll even if prevPath matches filePath.
+    const isFirstOpen = !wasOpen && isOpen;
+    if (prevPath === filePath && !isFirstOpen) {
       return;
     }
 


### PR DESCRIPTION
Fixes #221

## Problem
When opening inline diff mode, clicking any file except the first one would still scroll to the first file instead of the selected one.

## Root Cause
In `UnifiedDiffView.tsx`, the scroll logic had a bug:
- `prevFilePathForScrollRef` was initialized with the current `filePath` prop
- On first open, `prevPath === filePath` was true (both set to the selected file)  
- This caused an early return, skipping the scroll entirely

## Solution
Added tracking for the `isOpen` state transition:
- New `wasOpenRef` to track previous open state
- Detect when modal just opened (wasOpen=false → isOpen=true)
- Allow scroll when `prevPath === filePath` if it's the first open

## Testing
All 10 UnifiedDiffView tests pass.