### PR TITLE
Revert terminal improvements causing scroll navigation issues

### DIFF
--- a/src-tauri/src/commands/schaltwerk_core.rs
+++ b/src-tauri/src/commands/schaltwerk_core.rs
@@ -1437,8 +1437,6 @@ pub struct StartAgentParams {
     pub rows: Option<u16>,
     pub terminal_id: Option<String>,
     pub agent_type: Option<String>,
-    #[serde(default)]
-    pub prompt: Option<String>,
     pub skip_prompt: Option<bool>,
     pub skip_permissions: Option<bool>,
 }
@@ -1459,7 +1457,6 @@ pub async fn schaltwerk_core_start_session_agent(
             rows,
             terminal_id: None,
             agent_type: None,
-            prompt: None,
             skip_prompt: None,
             skip_permissions: None,
         },
@@ -1892,21 +1889,12 @@ pub async fn schaltwerk_core_start_session_agent_with_restart(
         rows,
         terminal_id,
         agent_type,
-        prompt,
         skip_prompt,
         skip_permissions,
     } = params;
     log::info!(
-        "[AGENT_LAUNCH_TRACE] schaltwerk_core_start_session_agent_with_restart called: session={session_name}, force_restart={force_restart}, terminal_id={terminal_id:?}, agent_type={agent_type:?}, skip_prompt={skip_prompt:?}, skip_permissions={skip_permissions:?}, prompt_override={}",
-        prompt.is_some()
+        "[AGENT_LAUNCH_TRACE] schaltwerk_core_start_session_agent_with_restart called: session={session_name}, force_restart={force_restart}, terminal_id={terminal_id:?}, agent_type={agent_type:?}, skip_prompt={skip_prompt:?}, skip_permissions={skip_permissions:?}"
     );
-    if let Some(prompt) = prompt.as_ref() {
-        let core = get_core_write().await?;
-        let manager = core.session_manager();
-        if let Err(err) = manager.update_session_initial_prompt(&session_name, prompt) {
-            log::warn!("Failed to update initial prompt for session '{session_name}': {err}");
-        }
-    }
     schaltwerk_core_start_agent_in_terminal(
         app,
         AgentStartParams {
@@ -1982,7 +1970,7 @@ pub async fn schaltwerk_core_start_claude_orchestrator(
     };
 
     let command_spec = manager
-        .start_agent_in_orchestrator(&binary_paths, agent_type.as_deref(), None)
+        .start_agent_in_orchestrator(&binary_paths, agent_type.as_deref())
         .map_err(|e| {
             log::error!("Failed to build orchestrator command: {e}");
             format!("Failed to start {agent_label} in orchestrator: {e}")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -327,22 +327,6 @@ pub async fn get_settings_manager(
 pub async fn get_terminal_manager()
 -> Result<Arc<schaltwerk::domains::terminal::TerminalManager>, String> {
     let manager = get_project_manager().await;
-
-    // Respect MCP request context if one is set for this task
-    if let Ok(Some(project_path)) = REQUEST_PROJECT_OVERRIDE.try_with(|cell| cell.borrow().clone())
-    {
-        match manager.get_terminal_manager_for_path(&project_path).await {
-            Ok(term) => return Ok(term),
-            Err(e) => {
-                log::error!(
-                    "Failed to get terminal manager for override path {}: {e}",
-                    project_path.display()
-                );
-                // Fall through to current project fallback
-            }
-        }
-    }
-
     manager
         .current_terminal_manager()
         .await

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -14,20 +14,15 @@ use schaltwerk::domains::settings::setup_script::SetupScriptService;
 use crate::commands::github::{CreateSessionPrArgs, github_create_session_pr_impl};
 use crate::commands::schaltwerk_core::{
     MergeCommandError, merge_session_with_events, schaltwerk_core_cancel_session,
-    schaltwerk_core_start_claude_orchestrator, schaltwerk_core_start_session_agent_with_restart,
-    StartAgentParams,
 };
 use crate::commands::sessions_refresh::{SessionsRefreshReason, request_sessions_refresh};
 use crate::mcp_api::diff_api::{DiffApiError, DiffChunkRequest, DiffScope, SummaryQuery};
-use crate::{REQUEST_PROJECT_OVERRIDE, get_core_read, get_core_write, SETTINGS_MANAGER};
+use crate::{REQUEST_PROJECT_OVERRIDE, get_core_read, get_core_write};
 use schaltwerk::domains::attention::get_session_attention_state;
 use schaltwerk::domains::merge::MergeMode;
 use schaltwerk::domains::sessions::entity::{Session, Spec};
 use schaltwerk::infrastructure::events::{emit_event, SchaltEvent};
 use schaltwerk::schaltwerk_core::{SessionManager, SessionState};
-use schaltwerk::schaltwerk_core::db_app_config::AppConfigMethods;
-use schaltwerk::shared::terminal_id::terminal_id_for_orchestrator_top;
-use crate::commands::schaltwerk_core::agent_launcher;
 
 mod diff_api;
 
@@ -60,7 +55,6 @@ async fn handle_mcp_request_inner(
     let path = req.uri().path().to_string();
 
     match (&method, path.as_str()) {
-        (&Method::POST, "/api/reset") => reset_selection(req, app).await,
         (&Method::GET, "/api/diff/summary") => diff_summary(req).await,
         (&Method::GET, "/api/diff/file") => diff_chunk(req).await,
         (&Method::POST, "/api/specs") => create_draft(req, app).await,
@@ -123,10 +117,6 @@ async fn handle_mcp_request_inner(
         {
             let name = extract_session_name_for_action(path, "/convert-to-spec");
             convert_session_to_spec(&name, app).await
-        }
-        (&Method::POST, path) if path.starts_with("/api/sessions/") && path.ends_with("/reset") => {
-            let name = extract_session_name_for_action(path, "/reset");
-            reset_session(req, &name, app).await
         }
         (&Method::GET, "/api/project/setup-script") => get_project_setup_script(app).await,
         (&Method::PUT, "/api/project/setup-script") => set_project_setup_script(req, app).await,
@@ -660,50 +650,6 @@ mod tests {
             .to_string();
         assert_eq!(value, "echo hi");
     }
-
-    #[test]
-    fn reset_session_request_defaults_to_none() {
-        let payload: ResetSessionRequest = serde_json::from_slice(b"{}").expect("payload");
-        assert!(payload.agent_type.is_none());
-        assert!(payload.prompt.is_none());
-        assert!(payload.skip_prompt.is_none());
-        assert!(payload.skip_permissions.is_none());
-    }
-
-    #[test]
-    fn reset_session_request_parses_optional_fields() {
-        let payload: ResetSessionRequest = serde_json::from_slice(
-            br#"{ "agent_type": "claude", "prompt": "hi", "skip_prompt": true, "skip_permissions": false }"#,
-        )
-        .expect("payload");
-        assert_eq!(payload.agent_type.as_deref(), Some("claude"));
-        assert_eq!(payload.prompt.as_deref(), Some("hi"));
-        assert_eq!(payload.skip_prompt, Some(true));
-        assert_eq!(payload.skip_permissions, Some(false));
-    }
-
-    #[test]
-    fn reset_selection_request_defaults_to_none() {
-        let payload = parse_reset_selection_request(b"").expect("payload");
-        assert!(payload.selection.is_none());
-        assert!(payload.session_name.is_none());
-        assert!(payload.agent_type.is_none());
-        assert!(payload.prompt.is_none());
-        assert!(payload.skip_prompt.is_none());
-        assert!(payload.skip_permissions.is_none());
-    }
-
-    #[test]
-    fn reset_selection_request_parses_fields() {
-        let payload = parse_reset_selection_request(
-            br#"{ "selection": "orchestrator", "agent_type": "opencode", "prompt": "go" }"#,
-        )
-        .expect("payload");
-        assert_eq!(payload.selection.as_deref(), Some("orchestrator"));
-        assert_eq!(payload.agent_type.as_deref(), Some("opencode"));
-        assert_eq!(payload.prompt.as_deref(), Some("go"));
-    }
-
 }
 
 async fn create_draft(
@@ -1179,286 +1125,6 @@ async fn create_session(
             ))
         }
     }
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-struct ResetSessionRequest {
-    #[serde(default)]
-    agent_type: Option<String>,
-    #[serde(default)]
-    prompt: Option<String>,
-    #[serde(default)]
-    skip_prompt: Option<bool>,
-    #[serde(default)]
-    skip_permissions: Option<bool>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-struct ResetSelectionRequest {
-    #[serde(default)]
-    selection: Option<String>,
-    #[serde(default)]
-    session_name: Option<String>,
-    #[serde(default)]
-    agent_type: Option<String>,
-    #[serde(default)]
-    prompt: Option<String>,
-    #[serde(default)]
-    skip_prompt: Option<bool>,
-    #[serde(default)]
-    skip_permissions: Option<bool>,
-}
-
-fn parse_reset_selection_request(body_bytes: &[u8]) -> Result<ResetSelectionRequest, (StatusCode, String)> {
-    if body_bytes.is_empty() {
-        return Ok(ResetSelectionRequest {
-            selection: None,
-            session_name: None,
-            agent_type: None,
-            prompt: None,
-            skip_prompt: None,
-            skip_permissions: None,
-        });
-    }
-    serde_json::from_slice::<ResetSelectionRequest>(body_bytes)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid JSON payload: {e}")))
-}
-
-async fn reset_selection(
-    req: Request<Incoming>,
-    app: tauri::AppHandle,
-) -> Result<Response<String>, hyper::Error> {
-    let body_bytes = req.into_body().collect().await?.to_bytes();
-    let payload = match parse_reset_selection_request(&body_bytes) {
-        Ok(p) => p,
-        Err((status, message)) => return Ok(error_response(status, message)),
-    };
-
-    match payload.selection.as_deref() {
-        Some("orchestrator") => reset_orchestrator(payload, app).await,
-        Some("session") => {
-            let name = match payload.session_name.as_deref() {
-                Some(v) if !v.trim().is_empty() => v,
-                _ => {
-                    return Ok(error_response(
-                        StatusCode::BAD_REQUEST,
-                        "Missing 'session_name' field for selection='session'".to_string(),
-                    ));
-                }
-            };
-
-            reset_session_with_payload(
-                name,
-                ResetSessionRequest {
-                    agent_type: payload.agent_type,
-                    prompt: payload.prompt,
-                    skip_prompt: payload.skip_prompt,
-                    skip_permissions: payload.skip_permissions,
-                },
-                app,
-            )
-            .await
-        }
-        Some(other) => Ok(error_response(
-            StatusCode::BAD_REQUEST,
-            format!("Invalid selection '{other}'. Expected 'orchestrator' or 'session'."),
-        )),
-        None => Ok(error_response(
-            StatusCode::BAD_REQUEST,
-            "Missing 'selection' field (expected 'orchestrator' or 'session')".to_string(),
-        )),
-    }
-}
-
-async fn reset_orchestrator(
-    payload: ResetSelectionRequest,
-    app: tauri::AppHandle,
-) -> Result<Response<String>, hyper::Error> {
-    let core = match get_core_write().await {
-        Ok(core) => core,
-        Err(e) => {
-            return Ok(error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Internal error: {e}"),
-            ));
-        }
-    };
-    let manager = core.session_manager();
-    if let Some(agent_type) = payload.agent_type.as_deref()
-        && let Err(e) = manager.set_orchestrator_agent_type(agent_type)
-    {
-        warn!("Failed to set orchestrator agent type: {e}");
-    }
-    if let Some(skip) = payload.skip_permissions
-        && let Err(e) = manager.set_orchestrator_skip_permissions(skip)
-    {
-        warn!("Failed to set orchestrator skip permissions: {e}");
-    }
-
-    let effective_agent_type = payload.agent_type.clone().unwrap_or_else(|| {
-        core.db
-            .get_orchestrator_agent_type()
-            .unwrap_or_else(|_| "claude".to_string())
-    });
-
-    let terminal_id = terminal_id_for_orchestrator_top(core.repo_path.as_path());
-    drop(core);
-
-    let start_result = start_orchestrator_with_prompt(
-        app.clone(),
-        terminal_id.clone(),
-        Some(effective_agent_type.clone()),
-        payload.prompt.as_deref(),
-        payload.skip_prompt.unwrap_or(false),
-    )
-    .await;
-
-    match start_result {
-        Ok(msg) => Ok(Response::new(msg)),
-        Err(err) => Ok(error_response(StatusCode::BAD_REQUEST, err)),
-    }
-}
-
-async fn start_orchestrator_with_prompt(
-    app: tauri::AppHandle,
-    terminal_id: String,
-    agent_type: Option<String>,
-    prompt: Option<&str>,
-    skip_prompt: bool,
-) -> Result<String, String> {
-    let Some(prompt) = prompt.filter(|p| !p.trim().is_empty()) else {
-        return schaltwerk_core_start_claude_orchestrator(app, terminal_id, None, None, agent_type).await;
-    };
-    if skip_prompt {
-        return schaltwerk_core_start_claude_orchestrator(app, terminal_id, None, None, agent_type)
-            .await;
-    }
-
-    let core = get_core_read().await?;
-    let manager = core.session_manager();
-    let db = core.db.clone();
-    let repo_path = core.repo_path.clone();
-    let binary_paths = if let Some(settings_manager) = SETTINGS_MANAGER.get() {
-        let settings = settings_manager.lock().await;
-        let mut paths = std::collections::HashMap::new();
-        for agent in [
-            "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp",
-            "kilocode",
-        ] {
-            if let Ok(path) = settings.get_effective_binary_path(agent) {
-                paths.insert(agent.to_string(), path);
-            }
-        }
-        paths
-    } else {
-        std::collections::HashMap::new()
-    };
-
-    let command_spec = manager.start_agent_in_orchestrator(
-        &binary_paths,
-        agent_type.as_deref(),
-        Some(prompt),
-    )
-    .map_err(|e| e.to_string())?;
-    drop(core);
-
-    let launch_result = agent_launcher::launch_in_terminal(
-        terminal_id,
-        command_spec,
-        &db,
-        repo_path.as_path(),
-        None,
-        None,
-        true,
-    )
-    .await;
-
-    launch_result.map(|_| "orchestrator-started".to_string())
-}
-
-async fn reset_session_with_payload(
-    name: &str,
-    payload: ResetSessionRequest,
-    app: tauri::AppHandle,
-) -> Result<Response<String>, hyper::Error> {
-    if let Ok(core) = get_core_write().await {
-        let manager = core.session_manager();
-        if let Some(agent_type) = payload.agent_type.as_deref() {
-            let skip = payload.skip_permissions.unwrap_or(false);
-            if let Err(e) = manager.set_session_original_settings(name, agent_type, skip) {
-                warn!("Failed to update session agent settings for '{name}': {e}");
-            } else {
-                request_sessions_refresh(&app, SessionsRefreshReason::SessionLifecycle);
-            }
-        } else if let Some(skip) = payload.skip_permissions
-            && let Ok(session) = manager.get_session(name)
-        {
-            let agent = session
-                .original_agent_type
-                .as_deref()
-                .unwrap_or("claude");
-            if let Err(e) = manager.set_session_original_settings(name, agent, skip) {
-                warn!("Failed to update session skip permissions for '{name}': {e}");
-            } else {
-                request_sessions_refresh(&app, SessionsRefreshReason::SessionLifecycle);
-            }
-        }
-    }
-
-    if payload.agent_type.is_some() || payload.skip_permissions.is_some() {
-        request_sessions_refresh(&app, SessionsRefreshReason::SessionLifecycle);
-    }
-
-    let result = schaltwerk_core_start_session_agent_with_restart(
-        app.clone(),
-        StartAgentParams {
-            session_name: name.to_string(),
-            force_restart: true,
-            cols: None,
-            rows: None,
-            terminal_id: None,
-            agent_type: payload.agent_type,
-            prompt: payload.prompt,
-            skip_prompt: payload.skip_prompt,
-            skip_permissions: payload.skip_permissions,
-        },
-    )
-    .await;
-
-    match result {
-        Ok(command) => Ok(Response::new(command)),
-        Err(err) => Ok(error_response(StatusCode::BAD_REQUEST, err)),
-    }
-}
-
-async fn reset_session(
-    req: Request<Incoming>,
-    name: &str,
-    app: tauri::AppHandle,
-) -> Result<Response<String>, hyper::Error> {
-    let body_bytes = req.into_body().collect().await?.to_bytes();
-    let payload: ResetSessionRequest = if body_bytes.is_empty() {
-        ResetSessionRequest {
-            agent_type: None,
-            prompt: None,
-            skip_prompt: None,
-            skip_permissions: None,
-        }
-    } else {
-        match serde_json::from_slice(&body_bytes) {
-            Ok(p) => p,
-            Err(e) => {
-                return Ok(error_response(
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid JSON payload: {e}"),
-                ));
-            }
-        }
-    };
-
-    reset_session_with_payload(name, payload, app).await
 }
 
 async fn list_sessions(req: Request<Incoming>) -> Result<Response<String>, hyper::Error> {

--- a/src-tauri/src/project_manager.rs
+++ b/src-tauri/src/project_manager.rs
@@ -460,54 +460,6 @@ impl ProjectManager {
         Ok(project.terminal_manager.clone())
     }
 
-    /// Get terminal manager for a specific project path
-    pub async fn get_terminal_manager_for_path(
-        &self,
-        path: &PathBuf,
-    ) -> Result<Arc<TerminalManager>> {
-        // Canonicalize the input path for consistent comparison
-        let canonical_path = match std::fs::canonicalize(path) {
-            Ok(p) => p,
-            Err(_) => path.clone(),
-        };
-
-        // First check if the path matches the current project
-        if let Some(current_path) = self.current_project_path().await {
-            let current_canonical = std::fs::canonicalize(&current_path).unwrap_or(current_path);
-            if current_canonical == canonical_path {
-                return self.current_terminal_manager().await;
-            }
-            if canonical_path.starts_with(&current_canonical) {
-                return self.current_terminal_manager().await;
-            }
-        }
-
-        // Check all loaded projects
-        let projects = self.projects.read().await;
-        for project in projects.values() {
-            let project_canonical =
-                std::fs::canonicalize(&project.path).unwrap_or(project.path.clone());
-            if project_canonical == canonical_path {
-                return Ok(project.terminal_manager.clone());
-            }
-            if canonical_path.starts_with(&project_canonical) {
-                return Ok(project.terminal_manager.clone());
-            }
-        }
-
-        // If project not loaded, try to load it without switching current
-        drop(projects);
-
-        let project = Project::new(canonical_path.clone())?;
-        let arc_project = Arc::new(project);
-
-        let mut projects_write = self.projects.write().await;
-        projects_write.insert(canonical_path.clone(), arc_project.clone());
-        drop(projects_write);
-
-        Ok(arc_project.terminal_manager.clone())
-    }
-
     /// Get SchaltwerkCore for current project
     pub async fn current_schaltwerk_core(&self) -> Result<Arc<RwLock<SchaltwerkCore>>> {
         let project = self.current_project().await?;

--- a/src-tauri/src/shared/terminal_id.rs
+++ b/src-tauri/src/shared/terminal_id.rs
@@ -89,45 +89,6 @@ pub fn terminal_id_for_session_bottom(name: &str) -> String {
     format!("{}-bottom", session_terminal_base(name))
 }
 
-pub fn terminal_id_for_orchestrator_top(project_path: &std::path::Path) -> String {
-    // Must match frontend computeProjectOrchestratorId(projectPath)
-    // - dirName = basename(projectPath)
-    // - sanitizedDirName = replace /[^a-zA-Z0-9_-]/g with '_'
-    // - hash = JS 32-bit: hash = ((hash << 5) - hash) + charCodeAt(i)
-    // - fragment = Math.abs(hash).toString(16).slice(0, 6)
-    // - id = `orchestrator-${sanitizedDirName}-${fragment}-top`
-    let dir_name = project_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown");
-
-    let sanitized: String = dir_name
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let sanitized = if sanitized.is_empty() {
-        "unknown".to_string()
-    } else {
-        sanitized
-    };
-
-    let mut hash: i32 = 0;
-    for unit in project_path.to_string_lossy().encode_utf16() {
-        hash = hash.wrapping_mul(31).wrapping_add(unit as i32);
-    }
-    let abs_hash: i64 = (hash as i64).abs();
-    let hex = format!("{abs_hash:x}");
-    let fragment = if hex.len() > 6 { &hex[..6] } else { &hex };
-
-    format!("orchestrator-{sanitized}-{fragment}-top")
-}
-
 pub fn previous_tilde_hashed_terminal_id_for_session_top(name: &str) -> String {
     format!("{}-top", session_terminal_base_v1(name))
 }
@@ -174,7 +135,6 @@ pub fn previous_hashed_terminal_id_for_session_bottom(name: &str) -> String {
 mod tests {
     use super::*;
     use std::collections::HashSet;
-    use std::path::Path;
 
     #[test]
     fn sanitizes_session_name_and_handles_empty() {
@@ -261,21 +221,5 @@ mod tests {
         assert!(is_session_top_terminal_id("orchestrator-main-top"));
         assert!(!is_session_top_terminal_id("orchestrator-main-bottom"));
         assert!(!is_session_top_terminal_id("run-terminal-main"));
-    }
-
-    #[test]
-    fn orchestrator_top_id_matches_expected_shape() {
-        let id = terminal_id_for_orchestrator_top(Path::new("/tmp/my project !@#"));
-        assert!(id.starts_with("orchestrator-my_project____-"));
-        assert!(id.ends_with("-top"));
-
-        let middle = id
-            .strip_prefix("orchestrator-my_project____-")
-            .unwrap()
-            .strip_suffix("-top")
-            .unwrap();
-        assert!(!middle.is_empty());
-        assert!(middle.chars().all(|c| c.is_ascii_hexdigit()));
-        assert!(middle.len() <= 6);
     }
 }

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -402,7 +402,6 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     const agentTypeRef = useRef(agentType);
     agentTypeRef.current = agentType;
     const isPhysicalWheelRef = useRef(true);
-    const shouldCaptureWheelRef = useRef(false);
     const isTerminalOnlyAgent = agentType === 'terminal';
     const isAgentTopTerminal = useMemo(() => {
         if (isTerminalOnlyAgent) {
@@ -530,6 +529,11 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
     }, [terminalId]);
 
     const shouldFilterMouseTracking = useCallback(() => {
+        const wrapper = xtermWrapperRef.current;
+        if (!wrapper) return true;
+        if (typeof wrapper.isTuiMode === 'function') {
+            return !wrapper.isTuiMode();
+        }
         return true;
     }, []);
 
@@ -911,61 +915,22 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
 
         const handleWheel = (event: WheelEvent) => {
             const next = classifyWheelEvent(event, isPhysicalWheelRef.current);
-            if (next !== isPhysicalWheelRef.current) {
-                isPhysicalWheelRef.current = next;
-                if (xtermWrapperRef.current) {
-                    xtermWrapperRef.current.setSmoothScrolling(smoothScrollingEnabled && next);
-                }
-            }
-
-            if (!shouldCaptureWheelRef.current) {
+            if (next === isPhysicalWheelRef.current) {
                 return;
             }
-
-            if (!terminal.current) {
-                return;
+            isPhysicalWheelRef.current = next;
+            if (xtermWrapperRef.current) {
+                xtermWrapperRef.current.setSmoothScrolling(smoothScrollingEnabled && next);
             }
-
-            const delta = event.deltaY;
-            if (!Number.isFinite(delta) || delta === 0) {
-                return;
-            }
-
-            event.preventDefault();
-            event.stopPropagation();
-            if (typeof event.stopImmediatePropagation === 'function') {
-                event.stopImmediatePropagation();
-            }
-
-            const buffer = terminal.current.buffer?.active;
-            if (!buffer) {
-                return;
-            }
-
-            if (buffer.baseY > 0) {
-                const multiplier = event.deltaMode === 1 ? 1 : 3;
-                const lines = Math.sign(delta) * Math.max(1, Math.ceil(Math.abs(delta) / 100) * multiplier);
-                terminal.current.scrollLines(lines);
-                logScrollChange('wheel');
-                return;
-            }
-
-            if (readOnlyRef.current) {
-                return;
-            }
-
-            const steps = Math.max(1, Math.ceil(Math.abs(delta) / 120));
-            const sequence = delta < 0 ? '\x1b[5~' : '\x1b[6~';
-            writeTerminalBackend(terminalId, sequence.repeat(steps)).catch(err => logger.debug('[Terminal] wheel scroll ignored (backend not ready yet)', err));
         };
         
         // Use capture phase for wheel events to intercept them before xterm consumes them
         // This is crucial for custom scrolling behavior or monitoring
-        node.addEventListener('wheel', handleWheel, { passive: false, capture: true });
+        node.addEventListener('wheel', handleWheel, { passive: true, capture: true });
         return () => {
             node.removeEventListener('wheel', handleWheel, { capture: true });
         };
-    }, [smoothScrollingEnabled, logScrollChange]);
+    }, [smoothScrollingEnabled]);
 
     useEffect(() => {
         if (!xtermWrapperRef.current) {
@@ -1292,10 +1257,8 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
                 logger.info(`[Terminal ${terminalId}] Syncing UI mode: ${currentMode} → ${mode} (agentType=${agentType})`);
                 instance.setUiMode(mode);
             }
-            instance.setMouseTrackingAllowed(!isAgentTopTerminal);
         }
-        shouldCaptureWheelRef.current = agentType === 'opencode' && isAgentTopTerminal;
-    }, [agentType, terminalId, isAgentTopTerminal]);
+    }, [agentType, terminalId]);
 
     useEffect(() => {
         debugCountersRef.current.initRuns += 1;
@@ -1335,8 +1298,6 @@ const TerminalComponent = forwardRef<TerminalHandle, TerminalProps>(({ terminalI
             instance.applyConfig(currentConfig);
         }
         instance.setUiMode(isTuiAgent(agentTypeRef.current) ? 'tui' : 'standard');
-        instance.setMouseTrackingAllowed(!isAgentTopTerminal);
-        shouldCaptureWheelRef.current = agentTypeRef.current === 'opencode' && isAgentTopTerminal;
         instance.setLinkHandler((uri: string) => handleLinkClickRef.current?.(uri) ?? false);
         instance.setSmoothScrolling(currentConfig.smoothScrolling && isPhysicalWheelRef.current);
         xtermWrapperRef.current = instance;

--- a/src/hooks/useSessionManagement.test.ts
+++ b/src/hooks/useSessionManagement.test.ts
@@ -268,9 +268,7 @@ describe('useSessionManagement', () => {
                     selection,
                     mockTerminals,
                     mockClearTerminalTracking,
-                    mockClearTerminalStartedTracking,
-                    undefined,
-                    'review prompt'
+                    mockClearTerminalStartedTracking
                 )
             })
 
@@ -284,8 +282,7 @@ describe('useSessionManagement', () => {
             expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreStartSessionAgentWithRestart, {
                 params: {
                     sessionName: 'test-session',
-                    forceRestart: false,
-                    prompt: 'review prompt'
+                    forceRestart: false
                 }
             })
             expect(mockClearTerminalTracking).toHaveBeenCalledWith(['test-terminal-top'])


### PR DESCRIPTION
## Summary
- Reverts commit 237b789b "feat: add MCP session reset endpoint with terminal improvements (#280)"
- This commit caused mouse wheel scrolling in Kilo/OpenCode terminals to send navigation keys instead of scrolling

## Root Cause
The reverted commit:
1. Blocked alternate scroll mode (1007) for all terminals
2. Disabled mouse tracking for agent terminals
3. Only added custom wheel handling for OpenCode, not Kilo

This caused wheel events in Kilo to fall through to xterm.js's fallback behavior, sending PageUp/PageDown sequences.

## Test plan
- [ ] Verify scrolling works correctly in Kilo terminal
- [ ] Verify scrolling works correctly in OpenCode terminal
- [ ] Verify no regression in regular terminal scrolling