### PR TITLE
Add GPT-5.5 support for Codex

### DIFF
--- a/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
+++ b/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
@@ -86,7 +86,7 @@ pub async fn collect_agent_env_and_cli(
             .into_iter()
             .collect::<Vec<_>>();
         if let Ok(project_env) = db.get_project_environment_variables(repo_path) {
-            env.extend(project_env.into_iter());
+            env.extend(project_env);
         }
         (
             env,

--- a/src-tauri/src/commands/schaltwerk_core/codex_models.rs
+++ b/src-tauri/src/commands/schaltwerk_core/codex_models.rs
@@ -120,6 +120,9 @@ fn to_title_case(input: &str) -> String {
     if input.is_empty() {
         return String::new();
     }
+    if input == "xhigh" {
+        return "Extra high".to_string();
+    }
     let mut chars = input.chars();
     let first = chars
         .next()
@@ -446,7 +449,8 @@ mod tests {
                         "supportedReasoningEfforts": [
                             { "reasoningEffort": "low", "description": "Fastest responses with limited reasoning" },
                             { "reasoningEffort": "medium", "description": "Dynamically adjusts reasoning based on the task" },
-                            { "reasoningEffort": "high", "description": "Maximizes reasoning depth for complex or ambiguous problems" }
+                            { "reasoningEffort": "high", "description": "Maximizes reasoning depth for complex or ambiguous problems" },
+                            { "reasoningEffort": "xhigh", "description": "" }
                         ],
                         "defaultReasoningEffort": "medium",
                         "isDefault": true
@@ -479,9 +483,15 @@ mod tests {
         assert_eq!(catalog.default_model_id, "gpt-5.1-codex");
         let first = &catalog.models[0];
         assert_eq!(first.id, "gpt-5.1-codex");
-        assert_eq!(first.reasoning_options.len(), 3);
+        assert_eq!(first.reasoning_options.len(), 4);
         assert_eq!(first.reasoning_options[0].id, "low");
         assert_eq!(first.reasoning_options[0].label, "Low");
+        assert_eq!(first.reasoning_options[3].id, "xhigh");
+        assert_eq!(first.reasoning_options[3].label, "Extra high");
+        assert_eq!(
+            first.reasoning_options[3].description,
+            "Extra high reasoning effort"
+        );
     }
 
     #[test]
@@ -522,12 +532,34 @@ mod tests {
     #[test]
     fn builtin_catalog_prefers_latest_models() {
         let catalog = builtin_codex_model_catalog();
-        assert_eq!(catalog.models[0].id, "gpt-5.3-codex");
+        assert_eq!(catalog.models[0].id, "gpt-5.5");
+        assert!(catalog.models.iter().any(|model| model.id == "gpt-5.4"));
+    }
+
+    #[test]
+    fn builtin_catalog_includes_gpt55_without_codex_variant_and_current_reasoning_efforts() {
+        let catalog = builtin_codex_model_catalog();
+        let model = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "gpt-5.5")
+            .expect("expected gpt-5.5 to be present in builtin catalog");
+
+        assert_eq!(catalog.default_model_id, "gpt-5.5");
+        assert_eq!(model.default_reasoning, "medium");
+        assert_eq!(
+            model
+                .reasoning_options
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["none", "low", "medium", "high", "xhigh"]
+        );
         assert!(
-            catalog
+            !catalog
                 .models
                 .iter()
-                .any(|model| model.id == "gpt-5.3-codex-spark")
+                .any(|model| model.id == "gpt-5.5-codex")
         );
     }
 

--- a/src-tauri/src/domains/projects/types.rs
+++ b/src-tauri/src/domains/projects/types.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -85,7 +86,7 @@ impl ProjectHistory {
 
     pub fn get_recent_projects(&self) -> Vec<RecentProject> {
         let mut projects: Vec<_> = self.projects.values().cloned().collect();
-        projects.sort_by(|a, b| b.last_opened.cmp(&a.last_opened));
+        projects.sort_by_key(|project| Reverse(project.last_opened));
         projects.truncate(20);
         projects
     }

--- a/src-tauri/src/domains/terminal/local.rs
+++ b/src-tauri/src/domains/terminal/local.rs
@@ -1226,10 +1226,8 @@ impl TerminalBackend for LocalPtyAdapter {
 fn session_id_from_terminal_id(id: &str) -> Option<String> {
     let mut rest = if let Some(suffix) = id.strip_prefix("session-") {
         suffix
-    } else if let Some(suffix) = id.strip_prefix("orchestrator-") {
-        suffix
     } else {
-        return None;
+        id.strip_prefix("orchestrator-")?
     };
 
     // Remove numeric index at end like -0, -1 FIRST

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use schaltwerk::domains::git::clone::{self, CloneOptions, RemoteMetadata};
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -86,7 +87,7 @@ impl ProjectHistory {
 
     pub fn get_recent_projects(&self) -> Vec<RecentProject> {
         let mut projects: Vec<_> = self.projects.values().cloned().collect();
-        projects.sort_by(|a, b| b.last_opened.cmp(&a.last_opened));
+        projects.sort_by_key(|project| Reverse(project.last_opened));
         projects.truncate(20);
         projects
     }

--- a/src/common/config/codexModels.json
+++ b/src/common/config/codexModels.json
@@ -1,13 +1,47 @@
 {
   "latest": {
-    "defaultModelId": "gpt-5.3-codex",
+    "defaultModelId": "gpt-5.5",
     "models": [
+      {
+        "id": "gpt-5.5",
+        "label": "GPT-5.5",
+        "description": "OpenAI's newest frontier model for complex coding, computer use, knowledge work, and research workflows in Codex.",
+        "defaultReasoning": "medium",
+        "isDefault": true,
+        "reasoningOptions": [
+          {
+            "id": "none",
+            "label": "None",
+            "description": "Bypasses deliberate reasoning for the fastest lightweight turns"
+          },
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balanced speed and reasoning depth"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Deep reasoning for complex coding tasks"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Maximum reasoning depth for the hardest problems"
+          }
+        ]
+      },
       {
         "id": "gpt-5.3-codex",
         "label": "GPT-5.3 Codex",
         "description": "Most capable Codex model for complex coding workflows.",
         "defaultReasoning": "high",
-        "isDefault": true,
+        "isDefault": false,
         "reasoningOptions": [
           {
             "id": "none",
@@ -160,7 +194,7 @@
       {
         "id": "gpt-5.4",
         "label": "GPT-5.4",
-        "description": "Latest frontier model with top-tier knowledge, reasoning and coding.",
+        "description": "Previous frontier model with top-tier knowledge, reasoning and coding.",
         "defaultReasoning": "medium",
         "isDefault": false,
         "reasoningOptions": [

--- a/src/services/codexModelCatalog.test.ts
+++ b/src/services/codexModelCatalog.test.ts
@@ -24,7 +24,8 @@ describe('codexModelCatalog', () => {
                     description: 'General purpose',
                     defaultReasoning: 'high',
                     reasoningOptions: [
-                        { id: 'low', label: 'Low', description: 'Low effort' }
+                        { id: 'low', label: 'Low', description: 'Low effort' },
+                        { id: 'xhigh', label: '', description: '' }
                     ]
                 }
             ],
@@ -38,6 +39,11 @@ describe('codexModelCatalog', () => {
         expect(catalog.models).toHaveLength(1)
         expect(catalog.models[0].id).toBe('gpt-5.3-codex')
         expect(catalog.models[0].reasoningOptions[0].id).toBe('low')
+        expect(catalog.models[0].reasoningOptions[1]).toEqual({
+            id: 'xhigh',
+            label: 'Extra high',
+            description: 'Extra high reasoning effort'
+        })
     })
 
     test('falls back to defaults when command fails', async () => {
@@ -47,18 +53,25 @@ describe('codexModelCatalog', () => {
 
         expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreListCodexModels)
         expect(catalog.models.length).toBeGreaterThan(0)
-        expect(catalog.models[0]?.id).toBe('gpt-5.3-codex')
+        expect(catalog.models[0]?.id).toBe('gpt-5.5')
         expect(catalog.defaultModelId).toBe(catalog.models[0]?.id ?? '')
     })
 
-    test('fallback catalog includes gpt-5.1-codex-max with extra high reasoning', async () => {
+    test('fallback catalog includes gpt-5.5 with current reasoning efforts', async () => {
         mockInvoke.mockRejectedValue(new Error('backend unavailable'))
 
         const catalog = await loadCodexModelCatalog()
-        const max = catalog.models.find(model => model.id === 'gpt-5.1-codex-max')
+        const gpt55 = catalog.models.find(model => model.id === 'gpt-5.5')
 
-        expect(max).toBeDefined()
-        expect(max?.defaultReasoning).toBe('medium')
-        expect(max?.reasoningOptions.map(option => option.id)).toContain('xhigh')
+        expect(gpt55).toBeDefined()
+        expect(gpt55?.defaultReasoning).toBe('medium')
+        expect(gpt55?.reasoningOptions.map(option => option.id)).toEqual([
+            'none',
+            'low',
+            'medium',
+            'high',
+            'xhigh',
+        ])
+        expect(catalog.models.some(model => model.id === 'gpt-5.5-codex')).toBe(false)
     })
 })

--- a/src/services/codexModelCatalog.ts
+++ b/src/services/codexModelCatalog.ts
@@ -28,6 +28,7 @@ const FALLBACK_CATALOG: CodexModelCatalog = (() => {
 
 function toTitleCase(value: string): string {
     if (!value) return ''
+    if (value === 'xhigh') return 'Extra high'
     const lower = value.toLowerCase()
     return lower.charAt(0).toUpperCase() + lower.slice(1)
 }


### PR DESCRIPTION
## Summary
- make gpt-5.5 the latest/default Codex model without adding a gpt-5.5-codex variant
- add the current GPT-5.5 reasoning efforts in the fallback catalog: none, low, medium, high, and xhigh
- normalize discovered xhigh reasoning labels to Extra high in frontend and backend catalog mapping

## Validation
- bun run test