### PR TITLE
feat(codex): support GPT-5.6 model family

### DIFF
--- a/docs-site/guides/agent-setup.mdx
+++ b/docs-site/guides/agent-setup.mdx
@@ -153,7 +153,7 @@ Arguments are parsed with shell-style quoting:
 ```
 
 ```bash Model Override
---model gpt-4
+--model gpt-5.6-sol
 ```
 
 ```bash Sandbox Mode
@@ -161,13 +161,23 @@ Arguments are parsed with shell-style quoting:
 ```
 
 ```bash Multiple Arguments
---profile work --model gpt-4 --verbose
+--profile work --model gpt-5.6-sol --verbose
 ```
 </CodeGroup>
 
 <Info>
   Codex launches are normalized automatically (single-dash long flags are fixed and profiles come before `--model`).
 </Info>
+
+For Codex, Schaltwerk reads the model catalog from your installed and authenticated CLI so the
+session dialog only offers models available to your account. Current GPT-5.6 choices include:
+
+- `gpt-5.6-sol` for the latest frontier capability
+- `gpt-5.6-terra` for balanced everyday work
+- `gpt-5.6-luna` for fast, lower-cost tasks
+
+If live discovery is unavailable, Schaltwerk uses a version-aware fallback catalog. Older Codex
+CLI versions keep their compatible model choices instead of receiving unsupported GPT-5.6 defaults.
 
 ### When Arguments Apply
 

--- a/src-tauri/src/commands/schaltwerk_core/codex_models.rs
+++ b/src-tauri/src/commands/schaltwerk_core/codex_models.rs
@@ -4,7 +4,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::Command;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -44,6 +44,7 @@ struct CodexModelConfigCatalog {
 #[serde(rename_all = "camelCase")]
 struct CodexModelConfigFile {
     latest: CodexModelConfigCatalog,
+    previous: CodexModelConfigCatalog,
     legacy: CodexModelConfigCatalog,
 }
 
@@ -156,27 +157,25 @@ fn legacy_codex_model_catalog() -> CodexModelCatalog {
     catalog_from_config(&CODEX_MODEL_CONFIG.legacy)
 }
 
+fn previous_codex_model_catalog() -> CodexModelCatalog {
+    catalog_from_config(&CODEX_MODEL_CONFIG.previous)
+}
+
 pub fn builtin_codex_model_catalog() -> CodexModelCatalog {
     latest_codex_model_catalog()
 }
 
 pub fn builtin_codex_model_catalog_for_version(cli_version: Option<&str>) -> CodexModelCatalog {
-    if codex_cli_supports_latest(cli_version) {
-        builtin_codex_model_catalog()
-    } else {
-        legacy_codex_model_catalog()
-    }
-}
-
-fn codex_cli_supports_latest(cli_version: Option<&str>) -> bool {
-    let Some(raw) = cli_version else {
-        return false;
+    let Some(version) = cli_version.and_then(parse_semver_from_string) else {
+        return legacy_codex_model_catalog();
     };
 
-    let parsed = parse_semver_from_string(raw);
-    match parsed {
-        Some(version) => version >= Version::new(0, 58, 0),
-        None => false,
+    if version >= Version::new(0, 145, 0) {
+        builtin_codex_model_catalog()
+    } else if version >= Version::new(0, 58, 0) {
+        previous_codex_model_catalog()
+    } else {
+        legacy_codex_model_catalog()
     }
 }
 
@@ -201,9 +200,10 @@ pub async fn fetch_codex_model_catalog<P: AsRef<Path>>(
 
     let mut command = Command::new(binary_path.as_ref());
     command
+        .kill_on_drop(true)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::null());
 
     for (key, value) in env_vars {
         command.env(key, value);
@@ -223,76 +223,113 @@ pub async fn fetch_codex_model_catalog<P: AsRef<Path>>(
         .take()
         .context("Failed to acquire Codex stdin for model discovery")?;
 
-    let request = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "model/list",
-        "params": { "pageSize": 50 }
+    let initialize_request = serde_json::json!({
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "clientInfo": {
+                "name": "schaltwerk",
+                "title": "Schaltwerk",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }
     });
 
-    let mut payload = serde_json::to_vec(&request)?;
-    payload.push(b'\n');
-
-    stdin
-        .write_all(&payload)
+    write_json_line(&mut stdin, &initialize_request)
         .await
-        .context("Failed to send model/list request to Codex")?;
-    stdin
-        .shutdown()
-        .await
-        .context("Failed to close Codex stdin after sending request")?;
-    drop(stdin);
+        .context("Failed to send initialize request to Codex")?;
 
     let stdout = child
         .stdout
         .take()
         .context("Failed to capture Codex stdout for model discovery")?;
+    let mut reader = BufReader::new(stdout).lines();
 
-    let response = {
-        let mut reader = BufReader::new(stdout).lines();
-        let mut captured: Option<serde_json::Value> = None;
-        while let Some(line) = reader
-            .next_line()
-            .await
-            .context("Failed to read Codex stdout during model discovery")?
-        {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
+    read_response(&mut reader, 0, "initialize").await?;
 
-            let value: serde_json::Value =
-                serde_json::from_str(trimmed).context("Failed to parse Codex stdout as JSON")?;
-            if value
-                .get("id")
-                .and_then(|v| v.as_i64())
-                .map(|id| id == 1)
-                .unwrap_or(false)
-            {
-                captured = Some(value);
-                break;
-            }
-        }
-        captured
-    };
+    let initialized_notification = serde_json::json!({
+        "method": "initialized",
+        "params": {}
+    });
+    write_json_line(&mut stdin, &initialized_notification)
+        .await
+        .context("Failed to acknowledge Codex initialization")?;
+
+    let model_list_request = serde_json::json!({
+        "id": 1,
+        "method": "model/list",
+        "params": { "pageSize": 50 }
+    });
+    write_json_line(&mut stdin, &model_list_request)
+        .await
+        .context("Failed to send model/list request to Codex")?;
+
+    let response = read_response(&mut reader, 1, "model/list").await?;
+
+    stdin
+        .shutdown()
+        .await
+        .context("Failed to close Codex stdin after model discovery")?;
+    drop(stdin);
 
     let status = child
         .wait()
         .await
         .context("Failed to wait for Codex CLI process to exit")?;
 
-    if let Some(value) = response {
-        map_models_from_json(&value)
-    } else if !status.success() {
+    if !status.success() {
         Err(anyhow::anyhow!(
             "Codex CLI exited with status {:?} before returning models",
             status.code()
         ))
     } else {
-        Err(anyhow::anyhow!(
-            "Codex CLI did not return a model list before exiting"
-        ))
+        map_models_from_json(&response)
     }
+}
+
+async fn write_json_line(
+    stdin: &mut tokio::process::ChildStdin,
+    value: &serde_json::Value,
+) -> Result<()> {
+    let mut payload = serde_json::to_vec(value)?;
+    payload.push(b'\n');
+    stdin.write_all(&payload).await?;
+    stdin.flush().await?;
+    Ok(())
+}
+
+async fn read_response<R>(
+    reader: &mut Lines<R>,
+    expected_id: i64,
+    method: &str,
+) -> Result<serde_json::Value>
+where
+    R: AsyncBufRead + Unpin,
+{
+    while let Some(line) = reader
+        .next_line()
+        .await
+        .with_context(|| format!("Failed to read Codex stdout during {method}"))?
+    {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let value: serde_json::Value =
+            serde_json::from_str(trimmed).context("Failed to parse Codex stdout as JSON")?;
+        if value.get("id").and_then(|id| id.as_i64()) != Some(expected_id) {
+            continue;
+        }
+
+        if let Some(error) = value.get("error") {
+            bail!("Codex {method} request failed: {error}");
+        }
+
+        return Ok(value);
+    }
+
+    bail!("Codex CLI exited before returning a {method} response")
 }
 
 pub async fn detect_codex_cli_version<P: AsRef<Path>>(binary_path: P) -> Option<String> {
@@ -320,8 +357,9 @@ fn map_models_from_json(value: &serde_json::Value) -> Result<CodexModelCatalog> 
         .context("Codex response missing result field")?;
 
     let items = result
-        .get("items")
-        .context("Codex response missing items field")?
+        .get("data")
+        .or_else(|| result.get("items"))
+        .context("Codex response missing data/items field")?
         .as_array()
         .context("Codex items field was not an array")?;
 
@@ -475,6 +513,48 @@ mod tests {
         })
     }
 
+    fn current_response() -> serde_json::Value {
+        serde_json::json!({
+            "id": 1,
+            "result": {
+                "data": [
+                    {
+                        "id": "gpt-5.6-sol",
+                        "model": "gpt-5.6-sol",
+                        "displayName": "GPT-5.6-Sol",
+                        "description": "Latest frontier agentic coding model.",
+                        "supportedReasoningEfforts": [
+                            { "reasoningEffort": "low", "description": "Fast responses with lighter reasoning" },
+                            { "reasoningEffort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+                            { "reasoningEffort": "high", "description": "Greater reasoning depth for complex problems" },
+                            { "reasoningEffort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+                            { "reasoningEffort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+                            { "reasoningEffort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
+                        ],
+                        "defaultReasoningEffort": "low",
+                        "isDefault": true
+                    },
+                    {
+                        "id": "gpt-5.6-luna",
+                        "model": "gpt-5.6-luna",
+                        "displayName": "GPT-5.6-Luna",
+                        "description": "Fast and affordable agentic coding model.",
+                        "supportedReasoningEfforts": [
+                            { "reasoningEffort": "low", "description": "Fast responses with lighter reasoning" },
+                            { "reasoningEffort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+                            { "reasoningEffort": "high", "description": "Greater reasoning depth for complex problems" },
+                            { "reasoningEffort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+                            { "reasoningEffort": "max", "description": "Maximum reasoning depth for the hardest problems" }
+                        ],
+                        "defaultReasoningEffort": "medium",
+                        "isDefault": false
+                    }
+                ],
+                "nextCursor": null
+            }
+        })
+    }
+
     #[test]
     fn maps_codex_models_from_json() {
         let value = sample_response();
@@ -491,6 +571,31 @@ mod tests {
         assert_eq!(
             first.reasoning_options[3].description,
             "Extra high reasoning effort"
+        );
+    }
+
+    #[test]
+    fn maps_current_codex_model_list_shape_and_reasoning_efforts() {
+        let catalog =
+            map_models_from_json(&current_response()).expect("expected current response to map");
+
+        assert_eq!(catalog.default_model_id, "gpt-5.6-sol");
+        assert_eq!(catalog.models[0].default_reasoning, "low");
+        assert_eq!(
+            catalog.models[0]
+                .reasoning_options
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+        );
+        assert_eq!(
+            catalog.models[1]
+                .reasoning_options
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low", "medium", "high", "xhigh", "max"]
         );
     }
 
@@ -530,42 +635,67 @@ mod tests {
     }
 
     #[test]
-    fn builtin_catalog_prefers_latest_models() {
+    fn builtin_catalog_prefers_gpt56_family() {
         let catalog = builtin_codex_model_catalog();
-        assert_eq!(catalog.models[0].id, "gpt-5.5");
-        assert!(catalog.models.iter().any(|model| model.id == "gpt-5.4"));
-    }
-
-    #[test]
-    fn builtin_catalog_includes_gpt55_without_codex_variant_and_current_reasoning_efforts() {
-        let catalog = builtin_codex_model_catalog();
-        let model = catalog
-            .models
-            .iter()
-            .find(|model| model.id == "gpt-5.5")
-            .expect("expected gpt-5.5 to be present in builtin catalog");
-
-        assert_eq!(catalog.default_model_id, "gpt-5.5");
-        assert_eq!(model.default_reasoning, "medium");
+        assert_eq!(catalog.default_model_id, "gpt-5.6-sol");
         assert_eq!(
-            model
-                .reasoning_options
+            catalog
+                .models
                 .iter()
-                .map(|option| option.id.as_str())
+                .take(3)
+                .map(|model| model.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["none", "low", "medium", "high", "xhigh"]
+            vec!["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
         );
         assert!(
             !catalog
                 .models
                 .iter()
-                .any(|model| model.id == "gpt-5.5-codex")
+                .any(|model| model.id == "gpt-5.3-codex")
         );
     }
 
     #[test]
-    fn builtin_catalog_includes_codex_max_with_extra_high_reasoning() {
+    fn builtin_catalog_includes_gpt56_family_with_current_reasoning_efforts() {
         let catalog = builtin_codex_model_catalog();
+        let sol = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "gpt-5.6-sol")
+            .expect("expected gpt-5.6-sol to be present in builtin catalog");
+        let terra = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "gpt-5.6-terra")
+            .expect("expected gpt-5.6-terra to be present in builtin catalog");
+        let luna = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "gpt-5.6-luna")
+            .expect("expected gpt-5.6-luna to be present in builtin catalog");
+
+        assert_eq!(sol.default_reasoning, "low");
+        assert_eq!(terra.default_reasoning, "medium");
+        assert_eq!(luna.default_reasoning, "medium");
+        assert_eq!(
+            sol.reasoning_options
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+        );
+        assert_eq!(
+            luna.reasoning_options
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low", "medium", "high", "xhigh", "max"]
+        );
+    }
+
+    #[test]
+    fn previous_catalog_keeps_codex_max_with_extra_high_reasoning() {
+        let catalog = previous_codex_model_catalog();
         let max = catalog
             .models
             .iter()
@@ -585,5 +715,12 @@ mod tests {
         let catalog = builtin_codex_model_catalog_for_version(Some("Codex CLI 0.57.2"));
         assert_eq!(catalog.models[0].id, "gpt-5-codex");
         assert!(catalog.models.iter().all(|model| !model.id.contains("5.1")));
+    }
+
+    #[test]
+    fn builtin_catalog_for_version_preserves_pre_gpt56_fallback() {
+        let catalog = builtin_codex_model_catalog_for_version(Some("codex-cli 0.144.0"));
+        assert_eq!(catalog.default_model_id, "gpt-5.5");
+        assert!(catalog.models.iter().all(|model| !model.id.contains("5.6")));
     }
 }

--- a/src-tauri/src/domains/sessions/lifecycle/finalizer.rs
+++ b/src-tauri/src/domains/sessions/lifecycle/finalizer.rs
@@ -71,7 +71,7 @@ impl<'a> SessionFinalizer<'a> {
         session_id: &str,
         new_state: SessionState,
     ) -> Result<()> {
-        let state_str = format!("{:?}", &new_state);
+        let state_str = format!("{new_state:?}");
         info!("Finalizing state transition for session '{session_id}' to {state_str}");
 
         self.db_manager

--- a/src/common/codexModels.ts
+++ b/src/common/codexModels.ts
@@ -22,6 +22,7 @@ export interface CodexModelCatalogDefinition {
 
 interface CodexModelConfiguration {
     latest: CodexModelCatalogDefinition
+    previous: CodexModelCatalogDefinition
     legacy: CodexModelCatalogDefinition
 }
 
@@ -44,6 +45,9 @@ export function cloneCodexCatalog(config: CodexModelCatalogDefinition): CodexMod
 export const LATEST_CODEX_CATALOG: CodexModelCatalogDefinition = cloneCodexCatalog(
     RAW_CODEX_MODEL_CONFIGURATION.latest
 )
+export const PREVIOUS_CODEX_CATALOG: CodexModelCatalogDefinition = cloneCodexCatalog(
+    RAW_CODEX_MODEL_CONFIGURATION.previous
+)
 export const LEGACY_CODEX_CATALOG: CodexModelCatalogDefinition = cloneCodexCatalog(
     RAW_CODEX_MODEL_CONFIGURATION.legacy
 )
@@ -58,6 +62,7 @@ export function getCodexModelMetadata(
 ): CodexModelMetadata | undefined {
     return (
         models.find(model => model.id === modelId) ||
+        PREVIOUS_CODEX_CATALOG.models.find(model => model.id === modelId) ||
         LEGACY_CODEX_CATALOG.models.find(model => model.id === modelId)
     )
 }

--- a/src/common/config/codexModels.json
+++ b/src/common/config/codexModels.json
@@ -1,5 +1,238 @@
 {
   "latest": {
+    "defaultModelId": "gpt-5.6-sol",
+    "models": [
+      {
+        "id": "gpt-5.6-sol",
+        "label": "GPT-5.6-Sol",
+        "description": "Latest frontier agentic coding model.",
+        "defaultReasoning": "low",
+        "isDefault": true,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          },
+          {
+            "id": "max",
+            "label": "Max",
+            "description": "Maximum reasoning depth for the hardest problems"
+          },
+          {
+            "id": "ultra",
+            "label": "Ultra",
+            "description": "Maximum reasoning with automatic task delegation"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.6-terra",
+        "label": "GPT-5.6-Terra",
+        "description": "Balanced agentic coding model for everyday work.",
+        "defaultReasoning": "medium",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          },
+          {
+            "id": "max",
+            "label": "Max",
+            "description": "Maximum reasoning depth for the hardest problems"
+          },
+          {
+            "id": "ultra",
+            "label": "Ultra",
+            "description": "Maximum reasoning with automatic task delegation"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "label": "GPT-5.6-Luna",
+        "description": "Fast and affordable agentic coding model.",
+        "defaultReasoning": "medium",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          },
+          {
+            "id": "max",
+            "label": "Max",
+            "description": "Maximum reasoning depth for the hardest problems"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.5",
+        "label": "GPT-5.5",
+        "description": "Frontier model for complex coding, research, and real-world work.",
+        "defaultReasoning": "medium",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.4",
+        "label": "GPT-5.4",
+        "description": "Strong model for everyday coding.",
+        "defaultReasoning": "medium",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.4-mini",
+        "label": "GPT-5.4-Mini",
+        "description": "Small, fast, and cost-efficient model for simpler coding tasks.",
+        "defaultReasoning": "medium",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          }
+        ]
+      },
+      {
+        "id": "gpt-5.3-codex-spark",
+        "label": "GPT-5.3-Codex-Spark",
+        "description": "Ultra-fast coding model.",
+        "defaultReasoning": "high",
+        "isDefault": false,
+        "reasoningOptions": [
+          {
+            "id": "low",
+            "label": "Low",
+            "description": "Fast responses with lighter reasoning"
+          },
+          {
+            "id": "medium",
+            "label": "Medium",
+            "description": "Balances speed and reasoning depth for everyday tasks"
+          },
+          {
+            "id": "high",
+            "label": "High",
+            "description": "Greater reasoning depth for complex problems"
+          },
+          {
+            "id": "xhigh",
+            "label": "Extra high",
+            "description": "Extra high reasoning depth for complex problems"
+          }
+        ]
+      }
+    ]
+  },
+  "previous": {
     "defaultModelId": "gpt-5.5",
     "models": [
       {

--- a/src/components/modals/SettingsModal.test.tsx
+++ b/src/components/modals/SettingsModal.test.tsx
@@ -480,6 +480,36 @@ describe('SettingsModal version settings', () => {
   })
 })
 
+describe('SettingsModal Codex model preferences', () => {
+  beforeEach(() => {
+    useSettingsMock.mockReset()
+    useSettingsMock.mockReturnValue(createDefaultUseSettingsValue())
+    useSessionsMock.mockReset()
+    useSessionsMock.mockReturnValue(createDefaultUseSessionsValue())
+    invokeMock.mockClear()
+    invokeMock.mockImplementation(baseInvokeImplementation)
+    requestDockBounceMock.mockReset()
+  })
+
+  it('suggests GPT-5.6 models and max reasoning efforts', async () => {
+    renderWithProviders(<SettingsModal open={true} onClose={() => {}} />)
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByRole('button', { name: 'Agent Configuration' }))
+    await user.click(await screen.findByRole('button', { name: 'Codex' }))
+
+    const modelOptions = document.querySelector<HTMLDataListElement>('#agent-model-options-codex')
+    const reasoningOptions = document.querySelector<HTMLDataListElement>('#agent-reasoning-options-codex')
+
+    expect(modelOptions?.querySelector('option[value="gpt-5.6-sol"]')).not.toBeNull()
+    expect(modelOptions?.querySelector('option[value="gpt-5.6-terra"]')).not.toBeNull()
+    expect(modelOptions?.querySelector('option[value="gpt-5.6-luna"]')).not.toBeNull()
+    expect(reasoningOptions?.querySelector('option[value="max"]')).not.toBeNull()
+    expect(reasoningOptions?.querySelector('option[value="ultra"]')).not.toBeNull()
+    expect(await screen.findAllByText(/--model gpt-5\.6-sol/)).toHaveLength(2)
+  })
+})
+
 describe('SettingsModal appearance settings', () => {
   beforeEach(() => {
     useSettingsMock.mockReset()

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -222,24 +222,14 @@ interface AgentPreferenceMetadata {
 }
 
 function buildCodexModelSuggestions(): AgentPreferenceMetadataOption[] {
-    const seen = new Set<string>()
-    const suggestions: AgentPreferenceMetadataOption[] = []
-    getAllCodexModels().forEach(model => {
-        model.reasoningOptions.forEach(option => {
-            const key = `${model.id} ${option.id}`
-            if (seen.has(key)) return
-            seen.add(key)
-            suggestions.push({
-                value: key,
-                label: key
-            })
-        })
-    })
-    return suggestions
+    return getAllCodexModels().map(model => ({
+        value: model.id,
+        label: model.label
+    }))
 }
 
 const CODEX_MODEL_SUGGESTIONS = buildCodexModelSuggestions()
-const CODEX_MODEL_PLACEHOLDER = CODEX_MODEL_SUGGESTIONS[0]?.value ?? 'gpt-5.3-codex high'
+const CODEX_MODEL_PLACEHOLDER = CODEX_MODEL_SUGGESTIONS[0]?.value ?? 'gpt-5.6-sol'
 
 const CODEX_REASONING_OPTIONS: AgentPreferenceMetadataOption[] = [
     { value: 'none', label: 'None' },
@@ -248,6 +238,8 @@ const CODEX_REASONING_OPTIONS: AgentPreferenceMetadataOption[] = [
     { value: 'medium', label: 'Medium' },
     { value: 'high', label: 'High' },
     { value: 'xhigh', label: 'Extra high' },
+    { value: 'max', label: 'Max' },
+    { value: 'ultra', label: 'Ultra' },
 ]
 
 const AGENT_PREFERENCE_METADATA: Record<AgentType, AgentPreferenceMetadata> = {
@@ -1810,7 +1802,7 @@ fi`}
                             style={{ fontVariantLigatures: 'none' }}
                         />
                         <div className="mt-2 text-caption text-text-muted">
-                            {t.settings.environment.cliArgsExamples} <code className="text-accent-blue">--profile test</code>, <code className="text-accent-blue">-d</code>, <code className="text-accent-blue">--model gpt-4</code>
+                            {t.settings.environment.cliArgsExamples} <code className="text-accent-blue">--profile test</code>, <code className="text-accent-blue">-d</code>, <code className="text-accent-blue">--model {activeAgentTab === 'codex' ? 'gpt-5.6-sol' : 'gpt-4'}</code>
                         </div>
                     </div>
                     )}
@@ -1946,13 +1938,11 @@ fi`}
                                 <ul className="mt-2 space-y-1 list-disc list-inside">
                                     <li><code>--sandbox workspace-write</code> - Workspace write access</li>
                                     <li><code>--sandbox danger-full-access</code> - Full system access</li>
-                                    <li><code>--model o3</code> - Use specific model</li>
+                                    <li><code>--model gpt-5.6-sol</code> - Use a specific model</li>
                                 </ul>
                                 <strong className="block mt-3">{t.settings.environment.commonClaudeEnvVars}</strong>
                                 <ul className="mt-2 space-y-1 list-disc list-inside">
                                     <li>OPENAI_API_KEY - Your OpenAI API key (if using OpenAI models)</li>
-                                    <li>CODEX_MODEL - Model to use (e.g., o3, gpt-4)</li>
-                                    <li>CODEX_PROFILE - Configuration profile to use</li>
                                 </ul>
                             </div>
                         </div>

--- a/src/components/shared/SessionConfigurationPanel.tsx
+++ b/src/components/shared/SessionConfigurationPanel.tsx
@@ -9,7 +9,11 @@ import { invoke } from '@tauri-apps/api/core'
 import { theme } from '../../common/theme'
 import { logger } from '../../utils/logger'
 import { AgentType, AGENT_TYPES, AGENT_SUPPORTS_SKIP_PERMISSIONS } from '../../types/session'
-import { FALLBACK_CODEX_MODELS, CodexModelMetadata } from '../../common/codexModels'
+import {
+    FALLBACK_CODEX_MODELS,
+    getCodexModelMetadata,
+    CodexModelMetadata
+} from '../../common/codexModels'
 import { useTranslation } from '../../common/i18n'
 
 interface SessionConfigurationPanelProps {
@@ -258,7 +262,7 @@ export function SessionConfigurationPanel({
 
     const selectedCodexMetadata = useMemo(() => {
         if (!codexModel) return undefined
-        return effectiveCodexModels.find(model => model.id === codexModel)
+        return getCodexModelMetadata(codexModel, effectiveCodexModels)
     }, [codexModel, effectiveCodexModels])
 
     // Ensure isValidBranch is considered "used" by TypeScript
@@ -513,11 +517,14 @@ function CodexModelSelector({
 
     const codexMetadataById = useMemo(() => {
         const map = new Map<string, CodexModelMetadata>()
-        codexModels.forEach(model => {
-            map.set(model.id, model)
+        normalizedOptions.forEach(option => {
+            const metadata = getCodexModelMetadata(option, codexModels)
+            if (metadata) {
+                map.set(option, metadata)
+            }
         })
         return map
-    }, [codexModels])
+    }, [codexModels, normalizedOptions])
 
     const selectedKey = useMemo(() => {
         if (!value) return undefined

--- a/src/services/codexModelCatalog.test.ts
+++ b/src/services/codexModelCatalog.test.ts
@@ -53,25 +53,37 @@ describe('codexModelCatalog', () => {
 
         expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SchaltwerkCoreListCodexModels)
         expect(catalog.models.length).toBeGreaterThan(0)
-        expect(catalog.models[0]?.id).toBe('gpt-5.5')
+        expect(catalog.models[0]?.id).toBe('gpt-5.6-sol')
         expect(catalog.defaultModelId).toBe(catalog.models[0]?.id ?? '')
     })
 
-    test('fallback catalog includes gpt-5.5 with current reasoning efforts', async () => {
+    test('fallback catalog includes the GPT-5.6 family with current reasoning efforts', async () => {
         mockInvoke.mockRejectedValue(new Error('backend unavailable'))
 
         const catalog = await loadCodexModelCatalog()
-        const gpt55 = catalog.models.find(model => model.id === 'gpt-5.5')
+        const sol = catalog.models.find(model => model.id === 'gpt-5.6-sol')
+        const terra = catalog.models.find(model => model.id === 'gpt-5.6-terra')
+        const luna = catalog.models.find(model => model.id === 'gpt-5.6-luna')
 
-        expect(gpt55).toBeDefined()
-        expect(gpt55?.defaultReasoning).toBe('medium')
-        expect(gpt55?.reasoningOptions.map(option => option.id)).toEqual([
-            'none',
+        expect(catalog.defaultModelId).toBe('gpt-5.6-sol')
+        expect(sol?.defaultReasoning).toBe('low')
+        expect(terra?.defaultReasoning).toBe('medium')
+        expect(luna?.defaultReasoning).toBe('medium')
+        expect(sol?.reasoningOptions.map(option => option.id)).toEqual([
             'low',
             'medium',
             'high',
             'xhigh',
+            'max',
+            'ultra',
         ])
-        expect(catalog.models.some(model => model.id === 'gpt-5.5-codex')).toBe(false)
+        expect(luna?.reasoningOptions.map(option => option.id)).toEqual([
+            'low',
+            'medium',
+            'high',
+            'xhigh',
+            'max',
+        ])
+        expect(catalog.models.some(model => model.id === 'gpt-5.3-codex')).toBe(false)
     })
 })


### PR DESCRIPTION
## Summary
- discover current Codex models through the required app-server initialization handshake and accept both current data and legacy items response shapes
- add version-aware GPT-5.6 Sol, Terra, and Luna fallback metadata while preserving older CLI catalogs for backward compatibility
- update model and reasoning selection surfaces, launch configuration guidance, validation metadata, and documentation
- fix one pre-existing Clippy warning required for the mandatory validation suite

## Verification
- CARGO_INCREMENTAL=0 just test
- authenticated Codex 0.145.0 model/list verification: Sol, Terra, and Luna with expected defaults and effort sets
- read-only Codex launch with gpt-5.6-sol and low reasoning returned SCHALTWERK_GPT56_OK