### PR TITLE
Add end-to-end Pi harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Native terminal AI agents with git worktree isolation. Spec-driven development for parallel workflows.**
 
-Run GitHub Copilot CLI, Claude Code, Kilo Code, OpenCode, Codex, Gemini, Qwen, Factory Droid, and Amp natively—no wrappers, no limitations. Or use Terminal Only mode for manual work. Each session gets its own worktree.
+Run GitHub Copilot CLI, Claude Code, Kilo Code, OpenCode, Codex, Pi, Gemini, Qwen, Factory Droid, and Amp natively—no wrappers, no limitations. Or use Terminal Only mode for manual work. Each session gets its own worktree.
 
 [![Test](https://github.com/2mawi2/schaltwerk/actions/workflows/test.yml/badge.svg)](https://github.com/2mawi2/schaltwerk/actions/workflows/test.yml)
 
@@ -32,7 +32,7 @@ Run GitHub Copilot CLI, Claude Code, Kilo Code, OpenCode, Codex, Gemini, Qwen, F
 - **Windows 10/11** (native; WSL not yet supported)
 - **Linux** - beta builds available via releases
 - **Git 2.30+**
-- At least one agentic coding CLI: GitHub Copilot CLI, Claude Code, OpenCode, Codex, Gemini, Qwen, Factory Droid, or Amp (or use Terminal Only mode for manual work)
+- At least one agentic coding CLI: GitHub Copilot CLI, Claude Code, OpenCode, Codex, Pi, Gemini, Qwen, Factory Droid, or Amp (or use Terminal Only mode for manual work)
 
 ## Quick Start (60 seconds)
 
@@ -91,7 +91,7 @@ Looking for multi-agent orchestration patterns? Check out the **Scaffold → Swa
 - Isolated branches (no conflicts between agents)
 - Squash-merge to main with one command
 - Direct PR creation via GitHub CLI integration
-- Session resumption support (Claude Code, Codex)
+- Session resumption support (Claude Code, Codex, Pi, and other supported agents)
 
 **Agent Configuration**
 - Custom environment variables per agent

--- a/codex-skills/schaltwerk-macos-cua/SKILL.md
+++ b/codex-skills/schaltwerk-macos-cua/SKILL.md
@@ -9,10 +9,10 @@ Run Schaltwerk natively while keeping the user's projects and normal app state o
 
 ## Prepare
 
-The host must have a working, authenticated real Codex CLI. The harness checks the
-current `PATH`, the Codex binaries bundled with ChatGPT and Codex, or the explicit
-`SCHALTWERK_CUA_CODEX_BIN` override. It fails before launching Schaltwerk if the
-binary is broken or `${CODEX_HOME:-~/.codex}/auth.json` is missing.
+The host must have working, authenticated real Codex and Pi CLIs. The harness checks
+the current `PATH`, the Codex binaries bundled with ChatGPT and Codex, or the explicit
+`SCHALTWERK_CUA_CODEX_BIN` and `SCHALTWERK_CUA_PI_BIN` overrides. It fails before
+launching Schaltwerk if either binary is broken or its authentication is missing.
 
 From the Schaltwerk repository root, run:
 
@@ -21,7 +21,7 @@ bun run cua:prepare
 bun run cua:verify-isolation
 ```
 
-`cua:prepare` builds the release `.app`, resets `logs/cua/macos-runtime`, creates a disposable Git fixture, and launches Schaltwerk with an isolated home and config database. It pins both model discovery and agent launch to the validated real Codex binary. The harness links only the user's existing Codex authentication into its isolated Codex home and pre-trusts only the disposable fixture root so a new worktree can start without first-run input. Use `bun run cua:prepare -- --no-build` only when the current app bundle already represents the source under test.
+`cua:prepare` builds the release `.app`, resets `logs/cua/macos-runtime`, creates a disposable Git fixture, and launches Schaltwerk with an isolated home and config database. It pins agent launch to the validated real Codex and Pi binaries. Codex authentication is linked into its isolated home; Pi authentication and model configuration are copied into isolated private files and removed on stop. The harness pre-trusts only the disposable fixture root for Codex. Use `bun run cua:prepare -- --no-build` only when the current app bundle already represents the source under test.
 
 If a harness instance is running, stop it before preparing again:
 
@@ -58,6 +58,12 @@ No Codex project-trust prompt should appear. Treat one as a harness failure: sto
 the run, prepare fresh state, and inspect
 `logs/cua/macos-runtime/codex-home/config.toml` before continuing.
 
+For the real-Pi flow, select Pi, select **Skip permissions** so project-local Pi
+resources are approved inside the disposable repository, and use a unique prompt
+and output file just like the Codex smoke flow. Confirm the prompt starts
+automatically, the file appears in Changes, and restarting the terminal resumes the
+same Pi session without replaying the initial prompt.
+
 ## Verify
 
 Check the process, isolation, logs, and Git effects:
@@ -76,7 +82,8 @@ only when the log also identifies the validated CLI version and the selected
 supported model completes the smoke task. Capture screenshots from Computer Use
 for visual findings.
 
-Always stop the owned test app when finished. Stopping also removes the temporary Codex authentication link:
+Always stop the owned test app when finished. Stopping also removes the temporary
+Codex authentication link and the isolated Pi authentication/configuration copies:
 
 ```bash
 bun run cua:stop

--- a/docker/cua/Dockerfile
+++ b/docker/cua/Dockerfile
@@ -42,7 +42,7 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY desktopctl.sh /usr/local/bin/desktopctl
 COPY agent-stub.sh /usr/local/bin/schaltwerk-agent-stub
 RUN chmod 755 /usr/local/bin/entrypoint.sh /usr/local/bin/desktopctl /usr/local/bin/schaltwerk-agent-stub \
-  && for agent in amp claude codex copilot droid gemini kilo opencode qwen; do \
+  && for agent in amp claude codex copilot droid gemini kilo opencode pi qwen; do \
     ln -s /usr/local/bin/schaltwerk-agent-stub "/usr/local/bin/$agent"; \
   done
 

--- a/docs-site/core-concepts.mdx
+++ b/docs-site/core-concepts.mdx
@@ -32,6 +32,9 @@ Schaltwerk’s workflow revolves around sessions (isolated git worktrees), reusa
   <Card title="Codex" icon="robot">
     Git-based AI agent from Stately used for repository automation. Configurable via Settings → Agent Configuration.
   </Card>
+  <Card title="Pi" icon="robot">
+    Extensible terminal coding agent launched through the `pi` CLI. Schaltwerk supplies the initial prompt and resumes Pi's worktree-specific session.
+  </Card>
   <Card title="OpenCode" icon="robot">
     Open-source terminal agent. Behaves similarly to Claude Code but uses the `opencode` CLI.
   </Card>

--- a/docs-site/first-session.mdx
+++ b/docs-site/first-session.mdx
@@ -71,6 +71,7 @@ Sessions are where AI agents work. Each session runs in its own isolated [git wo
   - **Claude Code** - Best for complex refactoring and understanding large codebases
   - **OpenCode** - Open-source option
   - **Codex** - Fast, efficient, great for smaller tasks
+  - **Pi** - Extensible terminal agent with configurable providers and models
   - **Gemini** - Alternative AI assistant
   - **Kilo Code** - Powerful CLI with architect and autonomous modes
   - **Qwen** - Alibaba's advanced AI coding assistant

--- a/docs-site/guides/agent-setup.mdx
+++ b/docs-site/guides/agent-setup.mdx
@@ -43,7 +43,7 @@ Configure each agent from **Settings → Agent Configuration** before you launch
 
 <Steps>
   <Step title="Select agent tab">
-  Choose from: GitHub Copilot, Claude Code, OpenCode, Codex, Gemini, Kilo Code, Qwen, Factory Droid, Amp, or Terminal
+  Choose from: GitHub Copilot, Claude Code, OpenCode, Codex, Pi, Gemini, Kilo Code, Qwen, Factory Droid, Amp, or Terminal
   </Step>
 
   <Step title="Pick binary">
@@ -118,6 +118,10 @@ After installation run `/login` in any Copilot session to authenticate.
 ~/.npm-global/bin/codex
 ```
 
+```bash Pi
+~/.local/bin/pi
+```
+
 ```bash Factory Droid
 ~/.local/bin/droid
 ```
@@ -178,6 +182,26 @@ session dialog only offers models available to your account. Current GPT-5.6 cho
 
 If live discovery is unavailable, Schaltwerk uses a version-aware fallback catalog. Older Codex
 CLI versions keep their compatible model choices instead of receiving unsupported GPT-5.6 defaults.
+
+### Pi
+
+Install and authenticate Pi before selecting it in Schaltwerk:
+
+```bash
+curl -fsSL https://pi.dev/install.sh | sh
+pi
+```
+
+Schaltwerk passes the initial task directly to Pi, adds `--approve` when **Skip permissions** is
+enabled, and resumes the newest Pi session associated with the worktree. Pi's **Model** preference
+maps to `--model`; use the full `provider/model-id` value shown by `pi --list-models`.
+
+Pi stores sessions below `~/.pi/agent/sessions` by default. If you set `PI_CODING_AGENT_DIR` or
+`PI_CODING_AGENT_SESSION_DIR` in Pi's agent environment, Schaltwerk uses the same location for
+session discovery.
+
+See the [Pi coding agent documentation](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)
+for authentication, model, and CLI configuration details.
 
 ### When Arguments Apply
 

--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -34,7 +34,7 @@ Run multiple AI agents on the same codebase—safely. Each agent works in an iso
   <Step title="Start an agent">
     Press `⌘N` to create a new session:
     - Enter a task description
-    - Select your agent (GitHub Copilot, Claude Code, OpenCode, Codex, Gemini, Kilo Code, Qwen, Factory Droid, Amp, or Terminal Only)
+    - Select your agent (GitHub Copilot, Claude Code, OpenCode, Codex, Pi, Gemini, Kilo Code, Qwen, Factory Droid, Amp, or Terminal Only)
     - Choose the base branch
     - Press `⌘Enter` to start
   </Step>

--- a/scripts/cua/macosHarness.js
+++ b/scripts/cua/macosHarness.js
@@ -27,6 +27,10 @@ export function createMacosHarnessPaths(repoRoot) {
     codexHomeDir: resolve(runtimeDir, 'codex-home'),
     codexAuthLink: resolve(runtimeDir, 'codex-home', 'auth.json'),
     codexConfigFile: resolve(runtimeDir, 'codex-home', 'config.toml'),
+    piAgentDir: resolve(runtimeDir, 'pi-agent'),
+    piAuthFile: resolve(runtimeDir, 'pi-agent', 'auth.json'),
+    piSettingsFile: resolve(runtimeDir, 'pi-agent', 'settings.json'),
+    piModelsFile: resolve(runtimeDir, 'pi-agent', 'models.json'),
     appBundle,
     appExecutable: resolve(appBundle, 'Contents', 'MacOS', 'schaltwerk'),
   })
@@ -43,7 +47,9 @@ export function buildMacosLaunchEnv(paths, baseEnv = process.env) {
     SCHALTWERK_APP_CONFIG_DB_PATH: paths.configDatabase,
     SCHALTWERK_CUA_RUNTIME_DIR: paths.runtimeDir,
     SCHALTWERK_CODEX_BINARY_PATH: resolve(paths.agentBinDir, 'codex'),
+    SCHALTWERK_PI_BINARY_PATH: resolve(paths.agentBinDir, 'pi'),
     CODEX_HOME: paths.codexHomeDir,
+    PI_CODING_AGENT_DIR: paths.piAgentDir,
     RUST_LOG: baseEnv.RUST_LOG ?? 'schaltwerk=debug',
     PATH: `${paths.agentBinDir}${delimiter}${systemPath}`,
   }

--- a/scripts/cua/macosHarness.test.js
+++ b/scripts/cua/macosHarness.test.js
@@ -33,6 +33,10 @@ describe('createMacosHarnessPaths', () => {
     expectDescendant(paths.runtimeDir, paths.codexHomeDir)
     expectDescendant(paths.runtimeDir, paths.codexAuthLink)
     expectDescendant(paths.runtimeDir, paths.codexConfigFile)
+    expectDescendant(paths.runtimeDir, paths.piAgentDir)
+    expectDescendant(paths.runtimeDir, paths.piAuthFile)
+    expectDescendant(paths.runtimeDir, paths.piSettingsFile)
+    expectDescendant(paths.runtimeDir, paths.piModelsFile)
   })
 
   it('targets the executable in the release macOS app bundle', () => {
@@ -67,7 +71,9 @@ describe('buildMacosLaunchEnv', () => {
       SCHALTWERK_APP_CONFIG_DB_PATH: paths.configDatabase,
       SCHALTWERK_CUA_RUNTIME_DIR: paths.runtimeDir,
       SCHALTWERK_CODEX_BINARY_PATH: resolve(paths.agentBinDir, 'codex'),
+      SCHALTWERK_PI_BINARY_PATH: resolve(paths.agentBinDir, 'pi'),
       CODEX_HOME: paths.codexHomeDir,
+      PI_CODING_AGENT_DIR: paths.piAgentDir,
       RUST_LOG: 'schaltwerk=debug',
       LANG: 'en_US.UTF-8',
     })
@@ -121,6 +127,7 @@ describe('native macOS repository integration', () => {
     expect(skill).toContain('bun run cua:verify-isolation')
     expect(skill).toContain('No Codex project-trust prompt should appear')
     expect(skill).toContain('SCHALTWERK_CUA_CODEX_BIN')
+    expect(skill).toContain('SCHALTWERK_CUA_PI_BIN')
   })
 
   it('launches the signed Codex app CLI instead of generated agent stubs', () => {
@@ -134,5 +141,22 @@ describe('native macOS repository integration', () => {
     expect(harness).toContain("run(candidate, ['--version']")
     expect(harness).not.toContain('prepareAgentStubs')
     expect(harness).not.toContain('Schaltwerk CUA agent stub')
+  })
+
+  it('launches the authenticated host Pi CLI with isolated mutable state', () => {
+    const harness = readFileSync(
+      resolve(repoRoot, 'scripts', 'cua', 'schaltwerk-macos.js'),
+      'utf8',
+    )
+
+    expect(harness).toContain('SCHALTWERK_CUA_PI_BIN')
+    expect(harness).toContain('prepareRealPi')
+    expect(harness).toContain("run(candidate, ['--version']")
+    expect(harness).toContain("run(piLink, ['--list-models']")
+  })
+
+  it('provides a Pi stub in the isolated Linux harness', () => {
+    const dockerfile = readFileSync(resolve(repoRoot, 'docker', 'cua', 'Dockerfile'), 'utf8')
+    expect(dockerfile).toMatch(/for agent in [^\n]*\bpi\b/)
   })
 })

--- a/scripts/cua/schaltwerk-macos.js
+++ b/scripts/cua/schaltwerk-macos.js
@@ -1,5 +1,7 @@
 import {
+  chmodSync,
   closeSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   openSync,
@@ -106,6 +108,7 @@ function resetRuntime() {
   mkdirSync(resolve(paths.configDatabase, '..'), { recursive: true })
   mkdirSync(paths.agentBinDir, { recursive: true })
   mkdirSync(paths.codexHomeDir, { recursive: true, mode: 0o700 })
+  mkdirSync(paths.piAgentDir, { recursive: true, mode: 0o700 })
 }
 
 function prepareFixture() {
@@ -183,6 +186,87 @@ function prepareRealCodex() {
   process.stdout.write(`Using real ${version} from ${binary}\n`)
 }
 
+function resolveRealPiBinary() {
+  let pathPi
+  try {
+    pathPi = run('/usr/bin/which', ['pi'], { capture: true })
+  } catch {
+    pathPi = null
+  }
+  const candidates = [
+    process.env.SCHALTWERK_CUA_PI_BIN,
+    pathPi,
+  ].filter(Boolean)
+
+  for (const candidate of [...new Set(candidates)]) {
+    if (!existsSync(candidate)) {
+      continue
+    }
+    try {
+      const version = run(candidate, ['--version'], { capture: true })
+      if (/^\d+\.\d+\.\d+/.test(version)) {
+        return { binary: candidate, version }
+      }
+    } catch {
+      continue
+    }
+  }
+  fail('No working real Pi CLI was found; install Pi or set SCHALTWERK_CUA_PI_BIN')
+}
+
+function copyPrivateFile(source, destination) {
+  copyFileSync(source, destination)
+  chmodSync(destination, 0o600)
+}
+
+function prepareRealPi() {
+  const { binary, version } = resolveRealPiBinary()
+  const piLink = resolve(paths.agentBinDir, 'pi')
+  const sourceAgentDir = process.env.PI_CODING_AGENT_DIR ?? resolve(process.env.HOME, '.pi', 'agent')
+  const sourceAuth = resolve(sourceAgentDir, 'auth.json')
+  const sourceSettings = resolve(sourceAgentDir, 'settings.json')
+  const sourceModels = resolve(sourceAgentDir, 'models.json')
+
+  if (!existsSync(sourceAuth)) {
+    fail(`Real Pi is not logged in; expected authentication at ${sourceAuth}`)
+  }
+
+  mkdirSync(paths.agentBinDir, { recursive: true })
+  mkdirSync(paths.piAgentDir, { recursive: true, mode: 0o700 })
+  rmSync(piLink, { force: true })
+  rmSync(paths.piAuthFile, { force: true })
+  rmSync(paths.piSettingsFile, { force: true })
+  rmSync(paths.piModelsFile, { force: true })
+  symlinkSync(binary, piLink)
+  copyPrivateFile(sourceAuth, paths.piAuthFile)
+
+  if (existsSync(sourceSettings)) {
+    const settings = JSON.parse(readFileSync(sourceSettings, 'utf8'))
+    delete settings.packages
+    writeFileSync(paths.piSettingsFile, `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 })
+  }
+  if (existsSync(sourceModels)) {
+    copyPrivateFile(sourceModels, paths.piModelsFile)
+  }
+
+  run(piLink, ['--list-models'], {
+    capture: true,
+    env: buildMacosLaunchEnv(paths),
+  })
+
+  writeFileSync(
+    resolve(paths.runtimeDir, 'pi.json'),
+    `${JSON.stringify({ binary, version }, null, 2)}\n`,
+  )
+  process.stdout.write(`Using real Pi ${version} from ${binary}\n`)
+}
+
+function removePiPrivateFiles() {
+  rmSync(paths.piAuthFile, { force: true })
+  rmSync(paths.piSettingsFile, { force: true })
+  rmSync(paths.piModelsFile, { force: true })
+}
+
 function buildApp() {
   run('bun', ['run', 'tauri', 'build', '--bundles', 'app'])
   if (!existsSync(paths.appExecutable)) {
@@ -200,33 +284,42 @@ function startApp() {
     fail('The Schaltwerk app bundle is missing; run bun run cua:prepare')
   }
 
-  prepareRealCodex()
-  mkdirSync(paths.runtimeDir, { recursive: true })
-  const logFd = openSync(paths.logFile, 'a')
-  const child = spawn(paths.appExecutable, [paths.fixtureDir], {
-    detached: true,
-    cwd: paths.fixtureDir,
-    env: buildMacosLaunchEnv(paths),
-    stdio: ['ignore', logFd, logFd],
-  })
-  child.unref()
-  closeSync(logFd)
-  writeFileSync(paths.pidFile, `${child.pid}\n`)
+  try {
+    prepareRealCodex()
+    prepareRealPi()
+    mkdirSync(paths.runtimeDir, { recursive: true })
+    const logFd = openSync(paths.logFile, 'a')
+    const child = spawn(paths.appExecutable, [paths.fixtureDir], {
+      detached: true,
+      cwd: paths.fixtureDir,
+      env: buildMacosLaunchEnv(paths),
+      stdio: ['ignore', logFd, logFd],
+    })
+    child.unref()
+    closeSync(logFd)
+    writeFileSync(paths.pidFile, `${child.pid}\n`)
 
-  process.stdout.write(`Started isolated Schaltwerk CUA process ${child.pid}\n`)
-  printStatus()
+    process.stdout.write(`Started isolated Schaltwerk CUA process ${child.pid}\n`)
+    printStatus()
+  } catch (error) {
+    rmSync(paths.codexAuthLink, { force: true })
+    removePiPrivateFiles()
+    throw error
+  }
 }
 
 function stopApp() {
   const pid = readOwnedPid()
   if (pid === null) {
     rmSync(paths.codexAuthLink, { force: true })
+    removePiPrivateFiles()
     process.stdout.write('Schaltwerk CUA is not running\n')
     return
   }
   if (!processIsRunning(pid)) {
     rmSync(paths.pidFile)
     rmSync(paths.codexAuthLink, { force: true })
+    removePiPrivateFiles()
     process.stdout.write(`Removed stale CUA pid file for process ${pid}\n`)
     return
   }
@@ -235,6 +328,7 @@ function stopApp() {
   process.kill(pid, 'SIGTERM')
   rmSync(paths.pidFile)
   rmSync(paths.codexAuthLink, { force: true })
+  removePiPrivateFiles()
   process.stdout.write(`Stopped Schaltwerk CUA process ${pid}\n`)
 }
 
@@ -259,6 +353,7 @@ function printStatus() {
     fixtureHead: head,
     isolatedHome: paths.homeDir,
     configDatabase: paths.configDatabase,
+    piAgentDir: paths.piAgentDir,
     log: paths.logFile,
   }
   process.stdout.write(`${JSON.stringify(status, null, 2)}\n`)

--- a/src-tauri/agents_manifest.toml
+++ b/src-tauri/agents_manifest.toml
@@ -75,6 +75,14 @@ default_binary_path = "kilo"
 auto_send_initial_command = false
 supports_resume = true
 
+[agents.pi]
+id = "pi"
+display_name = "Pi"
+binary_name = "pi"
+default_binary_path = "pi"
+auto_send_initial_command = false
+supports_resume = true
+
 [agents.terminal]
 id = "terminal"
 display_name = "Terminal Only"

--- a/src-tauri/src/commands/schaltwerk_core.rs
+++ b/src-tauri/src/commands/schaltwerk_core.rs
@@ -1550,6 +1550,7 @@ async fn schaltwerk_core_start_agent_in_terminal(
         // Get resolved binary paths for all agents
         for agent in [
             "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp", "kilo",
+            "pi",
         ] {
             match settings.get_effective_binary_path(agent) {
                 Ok(path) => {
@@ -1785,6 +1786,7 @@ async fn schaltwerk_core_start_agent_in_terminal(
         agent_ctx::AgentKind::Droid => "droid",
         agent_ctx::AgentKind::Qwen => "qwen",
         agent_ctx::AgentKind::Kilocode => "kilo",
+        agent_ctx::AgentKind::Pi => "pi",
         agent_ctx::AgentKind::Fallback => "claude",
     };
     log::info!(
@@ -1967,6 +1969,7 @@ pub async fn schaltwerk_core_start_claude_orchestrator(
 
         for agent in [
             "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp", "kilo",
+            "pi",
         ] {
             match settings.get_effective_binary_path(agent) {
                 Ok(path) => {
@@ -2641,7 +2644,7 @@ pub async fn schaltwerk_core_start_fresh_orchestrator(
 
         // Get resolved binary paths for all agents
         for agent in [
-            "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp",
+            "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp", "pi",
         ] {
             match settings.get_effective_binary_path(agent) {
                 Ok(path) => {

--- a/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
+++ b/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
@@ -17,6 +17,7 @@ pub enum AgentKind {
     Droid,
     Qwen,
     Kilocode,
+    Pi,
     Fallback,
 }
 
@@ -39,6 +40,8 @@ pub fn infer_agent_kind(agent_name: &str) -> AgentKind {
         AgentKind::Qwen
     } else if agent_name.contains("kilo") {
         AgentKind::Kilocode
+    } else if agent_name.ends_with("/pi") || agent_name.ends_with("\\pi") || agent_name == "pi" {
+        AgentKind::Pi
     } else {
         AgentKind::Fallback
     }
@@ -56,6 +59,7 @@ impl AgentKind {
             AgentKind::Droid => "droid",
             AgentKind::Qwen => "qwen",
             AgentKind::Kilocode => "kilo",
+            AgentKind::Pi => "pi",
             AgentKind::Fallback => "claude",
         }
     }
@@ -76,6 +80,7 @@ pub async fn collect_agent_env_and_cli(
         AgentKind::Droid => "droid",
         AgentKind::Qwen => "qwen",
         AgentKind::Kilocode => "kilo",
+        AgentKind::Pi => "pi",
         AgentKind::Fallback => "claude",
     };
 
@@ -179,11 +184,33 @@ pub fn build_final_args(
             }
             parsed_agent_args
         }
+        AgentKind::Pi => {
+            let extracted_prompt = extract_pi_prompt_if_present(&mut parsed_agent_args);
+            parsed_agent_args.extend(additional);
+            if let Some(prompt) = extracted_prompt {
+                parsed_agent_args.push(prompt);
+            }
+            parsed_agent_args
+        }
         _ => {
             parsed_agent_args.extend(additional);
             parsed_agent_args
         }
     }
+}
+
+fn extract_pi_prompt_if_present(args: &mut Vec<String>) -> Option<String> {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--approve" => index += 1,
+            "--session" => index += 2,
+            argument if argument.starts_with("--session=") => index += 1,
+            _ if index + 1 == args.len() => return Some(args.remove(index)),
+            _ => return None,
+        }
+    }
+    None
 }
 
 fn apply_agent_preferences(
@@ -192,7 +219,7 @@ fn apply_agent_preferences(
     additional_args: &mut Vec<String>,
     preferences: &AgentPreference,
 ) {
-    if matches!(agent_kind, AgentKind::Codex) {
+    if matches!(agent_kind, AgentKind::Codex | AgentKind::Pi) {
         match preferences
             .model
             .as_ref()
@@ -205,7 +232,9 @@ fn apply_agent_preferences(
             }
             _ => {}
         }
+    }
 
+    if matches!(agent_kind, AgentKind::Codex) {
         match preferences
             .reasoning_effort
             .as_ref()
@@ -221,6 +250,21 @@ fn apply_agent_preferences(
             {
                 additional_args.push("-c".to_string());
                 additional_args.push(format!(r#"model_reasoning_effort="{reasoning}""#));
+            }
+            _ => {}
+        }
+    }
+
+    if matches!(agent_kind, AgentKind::Pi) {
+        match preferences
+            .reasoning_effort
+            .as_ref()
+            .map(|reasoning| reasoning.trim())
+            .filter(|reasoning| !reasoning.is_empty())
+        {
+            Some(reasoning) if !has_flag(existing_args, additional_args, &["--thinking"]) => {
+                additional_args.push("--thinking".to_string());
+                additional_args.push(reasoning.to_string());
             }
             _ => {}
         }
@@ -335,6 +379,11 @@ mod tests {
         assert!(matches!(infer_agent_kind("qwen"), AgentKind::Qwen));
         assert!(matches!(infer_agent_kind("/usr/bin/qwen"), AgentKind::Qwen));
         assert!(matches!(infer_agent_kind("kilo"), AgentKind::Kilocode));
+        assert!(matches!(infer_agent_kind("pi"), AgentKind::Pi));
+        assert!(matches!(
+            infer_agent_kind("/usr/local/bin/pi"),
+            AgentKind::Pi
+        ));
         assert!(matches!(infer_agent_kind("unknown"), AgentKind::Fallback));
     }
 
@@ -382,6 +431,7 @@ mod tests {
         assert_eq!(AgentKind::Droid.manifest_key(), "droid");
         assert_eq!(AgentKind::Qwen.manifest_key(), "qwen");
         assert_eq!(AgentKind::Kilocode.manifest_key(), "kilo");
+        assert_eq!(AgentKind::Pi.manifest_key(), "pi");
         assert_eq!(AgentKind::Fallback.manifest_key(), "claude");
     }
 
@@ -474,6 +524,59 @@ mod tests {
                 "custom",
                 "-c",
                 "model_reasoning_effort=low"
+            ]
+        );
+    }
+
+    #[test]
+    fn pi_places_configuration_before_the_initial_prompt() {
+        let prefs = AgentPreference {
+            model: Some("openai-codex/gpt-5.6-terra".to_string()),
+            reasoning_effort: Some("high".to_string()),
+        };
+
+        let args = build_final_args(
+            &AgentKind::Pi,
+            vec!["--approve".into(), "inspect the repository".into()],
+            "--no-extensions",
+            &prefs,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "--approve",
+                "--no-extensions",
+                "--model",
+                "openai-codex/gpt-5.6-terra",
+                "--thinking",
+                "high",
+                "inspect the repository",
+            ]
+        );
+    }
+
+    #[test]
+    fn pi_model_preference_does_not_duplicate_custom_model_argument() {
+        let prefs = AgentPreference {
+            model: Some("openai-codex/gpt-5.6-terra".to_string()),
+            reasoning_effort: None,
+        };
+
+        let args = build_final_args(
+            &AgentKind::Pi,
+            vec!["--session".into(), "session-id".into()],
+            "--model anthropic/claude-sonnet-4-5",
+            &prefs,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "--session",
+                "session-id",
+                "--model",
+                "anthropic/claude-sonnet-4-5",
             ]
         );
     }

--- a/src-tauri/src/domains/agents/manifest.rs
+++ b/src-tauri/src/domains/agents/manifest.rs
@@ -62,6 +62,7 @@ mod tests {
         assert!(AgentManifest::get("droid").is_some());
         assert!(AgentManifest::get("copilot").is_some());
         assert!(AgentManifest::get("kilo").is_some());
+        assert!(AgentManifest::get("pi").is_some());
         assert!(AgentManifest::get("terminal").is_some());
     }
 
@@ -93,8 +94,8 @@ mod tests {
         assert!(agents.len() >= 10);
 
         let expected = vec![
-            "amp", "claude", "codex", "copilot", "droid", "gemini", "kilo", "opencode", "qwen",
-            "terminal",
+            "amp", "claude", "codex", "copilot", "droid", "gemini", "kilo", "opencode", "pi",
+            "qwen", "terminal",
         ];
         for agent in expected {
             assert!(agents.contains(&agent.to_string()));
@@ -128,6 +129,17 @@ mod tests {
         assert_eq!(terminal.default_binary_path, "/bin/sh");
         assert!(!terminal.auto_send_initial_command);
         assert!(!terminal.supports_resume);
+    }
+
+    #[test]
+    fn test_pi_definition() {
+        let pi = AgentManifest::get("pi").expect("Pi manifest entry missing");
+        assert_eq!(pi.id, "pi");
+        assert_eq!(pi.display_name, "Pi");
+        assert_eq!(pi.binary_name, "pi");
+        assert_eq!(pi.default_binary_path, "pi");
+        assert!(!pi.auto_send_initial_command);
+        assert!(pi.supports_resume);
     }
 
     #[test]

--- a/src-tauri/src/domains/agents/mod.rs
+++ b/src-tauri/src/domains/agents/mod.rs
@@ -12,6 +12,7 @@ pub mod launch_spec;
 pub mod manifest;
 pub mod naming;
 pub mod opencode;
+pub mod pi;
 pub mod qwen;
 pub mod unified;
 

--- a/src-tauri/src/domains/agents/pi.rs
+++ b/src-tauri/src/domains/agents/pi.rs
@@ -1,0 +1,272 @@
+use super::format_binary_invocation;
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Default)]
+pub struct PiConfig {
+    pub binary_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PiSessionHeader {
+    #[serde(rename = "type")]
+    entry_type: String,
+    id: String,
+    cwd: String,
+}
+
+fn pi_agent_dir() -> Option<PathBuf> {
+    std::env::var("PI_CODING_AGENT_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".pi").join("agent")))
+}
+
+pub(crate) fn pi_session_dir_for_worktree(worktree_path: &Path, agent_dir: &Path) -> PathBuf {
+    if let Ok(custom) = std::env::var("PI_CODING_AGENT_SESSION_DIR")
+        && !custom.trim().is_empty()
+    {
+        return PathBuf::from(custom);
+    }
+
+    let resolved = fs::canonicalize(worktree_path)
+        .unwrap_or_else(|_| worktree_path.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    let encoded = encode_pi_session_path(&resolved);
+
+    agent_dir.join("sessions").join(format!("--{encoded}--"))
+}
+
+fn encode_pi_session_path(resolved: &str) -> String {
+    let normalized = if let Some(path) = resolved.strip_prefix(r"\\?\UNC\") {
+        Cow::Owned(format!(r"\\{path}"))
+    } else if let Some(path) = resolved.strip_prefix(r"\\?\") {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Borrowed(resolved)
+    };
+    let without_root = normalized
+        .strip_prefix('/')
+        .or_else(|| normalized.strip_prefix('\\'))
+        .unwrap_or(&normalized);
+
+    without_root
+        .chars()
+        .map(|character| {
+            if matches!(character, '/' | '\\' | ':') {
+                '-'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn read_pi_session(path: &Path, worktree_path: &Path) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut lines = BufReader::new(file).lines();
+    let header_line = lines.next()?.ok()?;
+    let header: PiSessionHeader = serde_json::from_str(&header_line).ok()?;
+    if header.entry_type != "session" {
+        return None;
+    }
+
+    let resolved_worktree =
+        fs::canonicalize(worktree_path).unwrap_or_else(|_| worktree_path.to_path_buf());
+    let resolved_header =
+        fs::canonicalize(&header.cwd).unwrap_or_else(|_| PathBuf::from(&header.cwd));
+    if resolved_header != resolved_worktree {
+        return None;
+    }
+
+    let has_history = lines.map_while(Result::ok).any(|line| {
+        serde_json::from_str::<serde_json::Value>(&line)
+            .ok()
+            .is_some_and(|entry| {
+                entry.get("type").and_then(|value| value.as_str()) == Some("message")
+            })
+    });
+
+    has_history.then_some(header.id)
+}
+
+pub fn find_pi_session(worktree_path: &Path) -> Option<String> {
+    let agent_dir = pi_agent_dir()?;
+    let session_dir = pi_session_dir_for_worktree(worktree_path, &agent_dir);
+    let entries = fs::read_dir(session_dir).ok()?;
+
+    let mut candidates = entries
+        .flatten()
+        .filter(|entry| entry.path().extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .filter_map(|entry| {
+            let path = entry.path();
+            let id = read_pi_session(&path, worktree_path)?;
+            let modified = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let file_name = entry.file_name();
+            Some((modified, file_name, id))
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    candidates.pop().map(|(_, _, id)| id)
+}
+
+pub fn build_pi_command_with_config(
+    worktree_path: &Path,
+    session_id: Option<&str>,
+    initial_prompt: Option<&str>,
+    skip_permissions: bool,
+    config: Option<&PiConfig>,
+) -> String {
+    let binary = config
+        .and_then(|value| value.binary_path.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("pi");
+    let binary_invocation = format_binary_invocation(binary);
+    let cwd = format_binary_invocation(&worktree_path.display().to_string());
+    let mut command = format!("cd {cwd} && {binary_invocation}");
+
+    if let Some(id) = session_id.map(str::trim).filter(|value| !value.is_empty()) {
+        command.push_str(" --session ");
+        command.push_str(&format_binary_invocation(id));
+    }
+
+    if skip_permissions {
+        command.push_str(" --approve");
+    }
+
+    if let Some(prompt) = initial_prompt.filter(|value| !value.trim().is_empty()) {
+        let escaped = super::escape_prompt_for_shell(prompt);
+        command.push_str(" \"");
+        command.push_str(&escaped);
+        command.push('"');
+    }
+
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::command_parser::parse_agent_command;
+    use crate::utils::env_adapter::EnvAdapter;
+    use serial_test::serial;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn builds_new_session_with_initial_prompt_and_approval() {
+        let config = PiConfig {
+            binary_path: Some("pi".to_string()),
+        };
+        let command = build_pi_command_with_config(
+            Path::new("/path/to/worktree"),
+            None,
+            Some("implement feature X"),
+            true,
+            Some(&config),
+        );
+
+        assert_eq!(
+            command,
+            r#"cd /path/to/worktree && pi --approve "implement feature X""#
+        );
+    }
+
+    #[test]
+    fn resumes_exact_session_without_replaying_initial_prompt() {
+        let config = PiConfig {
+            binary_path: Some("/custom/pi".to_string()),
+        };
+        let command = build_pi_command_with_config(
+            Path::new("/path with spaces/worktree"),
+            Some("019f-session-id"),
+            None,
+            false,
+            Some(&config),
+        );
+
+        assert_eq!(
+            command,
+            r#"cd "/path with spaces/worktree" && /custom/pi --session 019f-session-id"#
+        );
+    }
+
+    #[test]
+    fn prompt_round_trips_through_shell_parser() {
+        let prompt = "Inspect \"$HOME\" and `status`\nthen keep C:\\\\tmp\\\\ intact";
+        let command = build_pi_command_with_config(
+            Path::new("/tmp/worktree"),
+            None,
+            Some(prompt),
+            false,
+            None,
+        );
+
+        let (_, agent, args) = parse_agent_command(&command).expect("Pi command should parse");
+        assert_eq!(agent, "pi");
+        assert_eq!(args.last().map(String::as_str), Some(prompt));
+    }
+
+    #[test]
+    fn session_directory_encoding_matches_pi_on_windows() {
+        assert_eq!(
+            encode_pi_session_path(r"\\?\C:\Users\dev\project"),
+            "C--Users-dev-project"
+        );
+        assert_eq!(
+            encode_pi_session_path(r"\\?\UNC\server\share\project"),
+            "-server-share-project"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn finds_newest_pi_session_with_history_for_worktree() {
+        let temp = tempdir().expect("temp dir");
+        let agent_dir = temp.path().join("pi-agent");
+        let worktree = temp.path().join("worktree");
+        fs::create_dir_all(&worktree).expect("worktree");
+        let session_dir = pi_session_dir_for_worktree(&worktree, &agent_dir);
+        fs::create_dir_all(&session_dir).expect("session dir");
+
+        fs::write(
+            session_dir.join("2026-01-01T00-00-00_old.jsonl"),
+            format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"old-id\",\"cwd\":{}}}\n",
+                serde_json::to_string(&worktree.to_string_lossy()).unwrap()
+            ),
+        )
+        .expect("old session");
+        fs::write(
+            session_dir.join("2026-01-02T00-00-00_new.jsonl"),
+            format!(
+                "{{\"type\":\"session\",\"version\":3,\"id\":\"new-id\",\"cwd\":{}}}\n\
+                 {{\"type\":\"message\",\"message\":{{\"role\":\"user\",\"content\":\"hello\"}}}}\n",
+                serde_json::to_string(&worktree.to_string_lossy()).unwrap()
+            ),
+        )
+        .expect("new session");
+
+        let previous = std::env::var("PI_CODING_AGENT_DIR").ok();
+        EnvAdapter::set_var("PI_CODING_AGENT_DIR", &agent_dir.to_string_lossy());
+        let found = find_pi_session(&worktree);
+        if let Some(value) = previous {
+            EnvAdapter::set_var("PI_CODING_AGENT_DIR", &value);
+        } else {
+            EnvAdapter::remove_var("PI_CODING_AGENT_DIR");
+        }
+
+        assert_eq!(found.as_deref(), Some("new-id"));
+    }
+}

--- a/src-tauri/src/domains/agents/tests/command_parser_tests.rs
+++ b/src-tauri/src/domains/agents/tests/command_parser_tests.rs
@@ -205,6 +205,15 @@ fn test_parse_agent_command_amp_with_full_path_pipeline() {
 }
 
 #[test]
+fn test_parse_agent_command_pi_with_prompt_and_approval() {
+    let cmd = r#"cd "/tmp/work tree" && /usr/local/bin/pi --approve "implement feature X""#;
+    let (cwd, agent, args) = parse_agent_command(cmd).unwrap();
+    assert_eq!(cwd, "/tmp/work tree");
+    assert_eq!(agent, "/usr/local/bin/pi");
+    assert_eq!(args, vec!["--approve", "implement feature X"]);
+}
+
+#[test]
 fn test_normalize_cwd_strips_double_quotes() {
     let result = normalize_cwd("\"/path with spaces\"");
     assert_eq!(result, "/path with spaces");

--- a/src-tauri/src/domains/agents/unified.rs
+++ b/src-tauri/src/domains/agents/unified.rs
@@ -5,6 +5,7 @@ use super::droid;
 use super::format_binary_invocation;
 use super::launch_spec::AgentLaunchSpec;
 use super::manifest::AgentManifest;
+use super::pi;
 use super::qwen;
 use log::warn;
 use std::collections::HashMap;
@@ -313,6 +314,35 @@ impl AgentAdapter for AmpAdapter {
     }
 }
 
+pub struct PiAdapter;
+
+impl AgentAdapter for PiAdapter {
+    fn find_session(&self, path: &Path) -> Option<AgentSessionInfo> {
+        pi::find_pi_session(path).map(|id| AgentSessionInfo {
+            id,
+            has_history: true,
+        })
+    }
+
+    fn build_launch_spec(&self, ctx: AgentLaunchContext) -> AgentLaunchSpec {
+        let config = pi::PiConfig {
+            binary_path: Some(
+                ctx.binary_override
+                    .unwrap_or(&ctx.manifest.default_binary_path)
+                    .to_string(),
+            ),
+        };
+        let command = pi::build_pi_command_with_config(
+            ctx.worktree_path,
+            ctx.session_id,
+            ctx.initial_prompt,
+            ctx.skip_permissions,
+            Some(&config),
+        );
+        AgentLaunchSpec::new(command, ctx.worktree_path.to_path_buf())
+    }
+}
+
 pub struct TerminalAdapter;
 
 impl AgentAdapter for TerminalAdapter {
@@ -337,6 +367,7 @@ impl AgentRegistry {
         adapters.insert("qwen".to_string(), Box::new(QwenAdapter));
         adapters.insert("amp".to_string(), Box::new(AmpAdapter));
         adapters.insert("kilo".to_string(), Box::new(KilocodeAdapter));
+        adapters.insert("pi".to_string(), Box::new(PiAdapter));
         adapters.insert("copilot".to_string(), Box::new(CopilotAdapter));
         adapters.insert("terminal".to_string(), Box::new(TerminalAdapter));
 
@@ -405,6 +436,7 @@ mod tests {
         assert!(registry.get("qwen").is_some());
         assert!(registry.get("amp").is_some());
         assert!(registry.get("kilo").is_some());
+        assert!(registry.get("pi").is_some());
         assert!(registry.get("copilot").is_some());
         assert!(registry.get("terminal").is_some());
     }
@@ -423,6 +455,7 @@ mod tests {
         assert!(supported.contains(&"qwen".to_string()));
         assert!(supported.contains(&"amp".to_string()));
         assert!(supported.contains(&"kilo".to_string()));
+        assert!(supported.contains(&"pi".to_string()));
         assert!(supported.contains(&"terminal".to_string()));
     }
 
@@ -552,6 +585,42 @@ mod tests {
 
             let spec = adapter.build_launch_spec(ctx);
             assert!(spec.shell_command.contains("opencode"));
+        }
+    }
+
+    mod pi_tests {
+        use super::*;
+
+        #[test]
+        fn test_pi_adapter_builds_initial_prompt_and_resume_commands() {
+            let adapter = PiAdapter;
+            let manifest = AgentManifest::get("pi").unwrap();
+
+            let fresh = adapter.build_launch_spec(AgentLaunchContext {
+                worktree_path: Path::new("/test/path"),
+                session_id: None,
+                initial_prompt: Some("test prompt"),
+                skip_permissions: true,
+                binary_override: Some("pi"),
+                manifest,
+            });
+            assert_eq!(
+                fresh.shell_command,
+                r#"cd /test/path && pi --approve "test prompt""#
+            );
+
+            let resumed = adapter.build_launch_spec(AgentLaunchContext {
+                worktree_path: Path::new("/test/path"),
+                session_id: Some("session-id"),
+                initial_prompt: None,
+                skip_permissions: false,
+                binary_override: Some("pi"),
+                manifest,
+            });
+            assert_eq!(
+                resumed.shell_command,
+                "cd /test/path && pi --session session-id"
+            );
         }
     }
 

--- a/src-tauri/src/domains/sessions/service.rs
+++ b/src-tauri/src/domains/sessions/service.rs
@@ -382,7 +382,7 @@ mod service_unified_tests {
         let _registry = crate::domains::agents::unified::AgentRegistry::new();
 
         // Test each supported agent type
-        for (i, agent_type) in ["claude", "codex", "gemini", "opencode", "kilo"]
+        for (i, agent_type) in ["claude", "codex", "gemini", "opencode", "kilo", "pi"]
             .iter()
             .enumerate()
         {

--- a/src-tauri/src/domains/settings/service.rs
+++ b/src-tauri/src/domains/settings/service.rs
@@ -6,11 +6,13 @@ fn agent_binary_override_with<F>(agent_name: &str, lookup: F) -> Option<String>
 where
     F: Fn(&str) -> Option<String>,
 {
-    if agent_name != "codex" {
-        return None;
-    }
+    let variable = match agent_name {
+        "codex" => "SCHALTWERK_CODEX_BINARY_PATH",
+        "pi" => "SCHALTWERK_PI_BINARY_PATH",
+        _ => return None,
+    };
 
-    lookup("SCHALTWERK_CODEX_BINARY_PATH")
+    lookup(variable)
         .map(|path| path.trim().to_string())
         .filter(|path| !path.is_empty())
 }
@@ -76,6 +78,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_env_vars.qwen.clone(),
             "amp" => self.settings.agent_env_vars.amp.clone(),
             "kilo" => self.settings.agent_env_vars.kilo.clone(),
+            "pi" => self.settings.agent_env_vars.pi.clone(),
             "terminal" => self.settings.agent_env_vars.terminal.clone(),
             _ => HashMap::new(),
         }
@@ -96,6 +99,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_env_vars.qwen = env_vars,
             "amp" => self.settings.agent_env_vars.amp = env_vars,
             "kilo" => self.settings.agent_env_vars.kilo = env_vars,
+            "pi" => self.settings.agent_env_vars.pi = env_vars,
             "terminal" => self.settings.agent_env_vars.terminal = env_vars,
             _ => {
                 return Err(SettingsServiceError::UnknownAgentType(
@@ -171,6 +175,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_cli_args.qwen.clone(),
             "amp" => self.settings.agent_cli_args.amp.clone(),
             "kilo" => self.settings.agent_cli_args.kilo.clone(),
+            "pi" => self.settings.agent_cli_args.pi.clone(),
             _ => String::new(),
         }
     }
@@ -199,6 +204,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_cli_args.qwen = cli_args.clone(),
             "amp" => self.settings.agent_cli_args.amp = cli_args.clone(),
             "kilo" => self.settings.agent_cli_args.kilo = cli_args.clone(),
+            "pi" => self.settings.agent_cli_args.pi = cli_args.clone(),
             _ => {
                 let error = format!("Unknown agent type: {agent_type}");
                 log::error!("Invalid agent type in set_agent_cli_args: {error}");
@@ -233,6 +239,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_initial_commands.qwen.clone(),
             "amp" => self.settings.agent_initial_commands.amp.clone(),
             "kilo" => self.settings.agent_initial_commands.kilo.clone(),
+            "pi" => self.settings.agent_initial_commands.pi.clone(),
             "terminal" => String::new(),
             _ => String::new(),
         }
@@ -249,6 +256,7 @@ impl SettingsService {
             "qwen" => Some(&self.settings.agent_preferences.qwen),
             "amp" => Some(&self.settings.agent_preferences.amp),
             "kilo" => Some(&self.settings.agent_preferences.kilo),
+            "pi" => Some(&self.settings.agent_preferences.pi),
             "terminal" => Some(&self.settings.agent_preferences.terminal),
             _ => None,
         }
@@ -268,6 +276,7 @@ impl SettingsService {
             "qwen" => Ok(&mut self.settings.agent_preferences.qwen),
             "amp" => Ok(&mut self.settings.agent_preferences.amp),
             "kilo" => Ok(&mut self.settings.agent_preferences.kilo),
+            "pi" => Ok(&mut self.settings.agent_preferences.pi),
             "terminal" => Ok(&mut self.settings.agent_preferences.terminal),
             _ => Err(SettingsServiceError::UnknownAgentType(
                 agent_type.to_string(),
@@ -311,6 +320,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_initial_commands.qwen = initial_command.clone(),
             "amp" => self.settings.agent_initial_commands.amp = initial_command.clone(),
             "kilo" => self.settings.agent_initial_commands.kilo = initial_command.clone(),
+            "pi" => self.settings.agent_initial_commands.pi = initial_command.clone(),
             "terminal" => {}
             _ => {
                 let error = format!("Unknown agent type: {agent_type}");
@@ -438,6 +448,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_binaries.qwen.clone(),
             "amp" => self.settings.agent_binaries.amp.clone(),
             "kilo" => self.settings.agent_binaries.kilo.clone(),
+            "pi" => self.settings.agent_binaries.pi.clone(),
             "terminal" => None,
             _ => None,
         }
@@ -462,6 +473,7 @@ impl SettingsService {
             "qwen" => self.settings.agent_binaries.qwen = Some(config),
             "amp" => self.settings.agent_binaries.amp = Some(config),
             "kilo" => self.settings.agent_binaries.kilo = Some(config),
+            "pi" => self.settings.agent_binaries.pi = Some(config),
             _ => return Err(SettingsServiceError::UnknownAgentType(config.agent_name)),
         }
         self.save()
@@ -494,6 +506,9 @@ impl SettingsService {
             configs.push(config.clone());
         }
         if let Some(config) = &self.settings.agent_binaries.kilo {
+            configs.push(config.clone());
+        }
+        if let Some(config) = &self.settings.agent_binaries.pi {
             configs.push(config.clone());
         }
         configs
@@ -659,6 +674,52 @@ mod tests {
         assert_eq!(
             repo_handle.snapshot().agent_cli_args.kilo,
             "--mode architect"
+        );
+    }
+
+    #[test]
+    fn settings_support_all_pi_configuration() {
+        let repo = InMemoryRepository::default();
+        let repo_handle = repo.clone();
+        let mut service = SettingsService::new(Box::new(repo));
+
+        service
+            .set_agent_cli_args("pi", "--model openai/gpt-5".to_string())
+            .expect("should accept Pi CLI args");
+        service
+            .set_agent_initial_command("pi", "build project".to_string())
+            .expect("should accept Pi initial command");
+        let vars = HashMap::from([("PI_OFFLINE".to_string(), "1".to_string())]);
+        service
+            .set_agent_env_vars("pi", vars.clone())
+            .expect("should accept Pi env vars");
+        let binary = AgentBinaryConfig {
+            agent_name: "pi".to_string(),
+            custom_path: Some("/custom/pi".to_string()),
+            auto_detect: false,
+            detected_binaries: vec![],
+        };
+        service
+            .set_agent_binary_config(binary.clone())
+            .expect("should accept Pi binary config");
+
+        let snapshot = repo_handle.snapshot();
+        assert_eq!(snapshot.agent_cli_args.pi, "--model openai/gpt-5");
+        assert_eq!(snapshot.agent_initial_commands.pi, "build project");
+        assert_eq!(snapshot.agent_env_vars.pi, vars);
+        assert_eq!(snapshot.agent_binaries.pi, Some(binary));
+    }
+
+    #[test]
+    fn pi_binary_override_reads_nonempty_harness_path() {
+        let lookup = |key: &str| match key {
+            "SCHALTWERK_PI_BINARY_PATH" => Some("/tmp/cua/bin/pi".to_string()),
+            _ => None,
+        };
+
+        assert_eq!(
+            agent_binary_override_with("pi", lookup),
+            Some("/tmp/cua/bin/pi".to_string())
         );
     }
 

--- a/src-tauri/src/domains/settings/types.rs
+++ b/src-tauri/src/domains/settings/types.rs
@@ -33,6 +33,8 @@ pub struct AgentCliArgs {
     pub amp: String,
     #[serde(default)]
     pub kilo: String,
+    #[serde(default)]
+    pub pi: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -49,6 +51,8 @@ pub struct AgentInitialCommands {
     pub amp: String,
     #[serde(default)]
     pub kilo: String,
+    #[serde(default)]
+    pub pi: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -65,6 +69,8 @@ pub struct AgentEnvVars {
     pub amp: HashMap<String, String>,
     #[serde(default)]
     pub kilo: HashMap<String, String>,
+    #[serde(default)]
+    pub pi: HashMap<String, String>,
     pub terminal: HashMap<String, String>,
 }
 
@@ -96,6 +102,8 @@ pub struct AgentPreferences {
     pub amp: AgentPreference,
     #[serde(default)]
     pub kilo: AgentPreference,
+    #[serde(default)]
+    pub pi: AgentPreference,
     #[serde(default)]
     pub terminal: AgentPreference,
 }
@@ -280,6 +288,8 @@ pub struct AgentBinaryConfigs {
     pub amp: Option<AgentBinaryConfig>,
     #[serde(default)]
     pub kilo: Option<AgentBinaryConfig>,
+    #[serde(default)]
+    pub pi: Option<AgentBinaryConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/domains/settings/validation.rs
+++ b/src-tauri/src/domains/settings/validation.rs
@@ -65,4 +65,5 @@ pub fn clean_invalid_binary_paths(settings: &mut Settings) {
     fix_config(&mut settings.agent_binaries.qwen);
     fix_config(&mut settings.agent_binaries.amp);
     fix_config(&mut settings.agent_binaries.kilo);
+    fix_config(&mut settings.agent_binaries.pi);
 }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -2411,7 +2411,7 @@ async fn start_orchestrator_with_prompt(
         let mut paths = std::collections::HashMap::new();
         for agent in [
             "claude", "copilot", "codex", "opencode", "gemini", "droid", "qwen", "amp",
-            "kilo",
+            "kilo", "pi",
         ] {
             if let Ok(path) = settings.get_effective_binary_path(agent) {
                 paths.insert(agent.to_string(), path);

--- a/src/components/inputs/ModelSelector.tsx
+++ b/src/components/inputs/ModelSelector.tsx
@@ -17,6 +17,7 @@ const MODEL_METADATA: Record<AgentType, { label: string; color: ModelColor }> = 
     qwen: { label: 'Qwen', color: 'cyan' },
     amp: { label: 'Amp', color: 'yellow' },
     kilo: { label: 'Kilo Code', color: 'yellow' },
+    pi: { label: 'Pi', color: 'violet' },
     terminal: { label: 'Terminal Only', color: 'green' }
 }
 

--- a/src/components/modals/NewSessionModal.test.tsx
+++ b/src/components/modals/NewSessionModal.test.tsx
@@ -375,9 +375,11 @@ describe('NewSessionModal', () => {
   it('prefills spec content when schaltwerk:new-session:prefill event is dispatched', async () => {
     render(<ModalProvider><NewSessionModal open={true} onClose={() => {}} onCreate={vi.fn()} /></ModalProvider>)
     
+    expect(screen.getByText('Describe the task for this agent')).toBeInTheDocument()
+
     // Initially the agent content editor should be empty (ignoring placeholder text)
     const initialContent = getTaskEditorContent()
-    expect(initialContent === '' || initialContent === 'Describe the agent for the Claude session').toBe(true)
+    expect(initialContent === '' || initialContent === 'Describe the task for this agent').toBe(true)
     
     // Dispatch the prefill event with spec content
     const draftContent = '# My Spec\n\nThis is the spec content that should be prefilled.'

--- a/src/components/modals/SettingsModal.test.tsx
+++ b/src/components/modals/SettingsModal.test.tsx
@@ -193,6 +193,7 @@ const createEmptyEnvVars = () => ({
   opencode: [],
   gemini: [],
   codex: [],
+  pi: [],
 })
 
 const createEmptyCliArgs = () => ({
@@ -200,6 +201,7 @@ const createEmptyCliArgs = () => ({
   opencode: '',
   gemini: '',
   codex: '',
+  pi: '',
 })
 
 const createEmptyPreferences = () => ({
@@ -210,6 +212,7 @@ const createEmptyPreferences = () => ({
   droid: { model: '', reasoningEffort: '' },
   qwen: { model: '', reasoningEffort: '' },
   amp: { model: '', reasoningEffort: '' },
+  pi: { model: '', reasoningEffort: '' },
   terminal: { model: '', reasoningEffort: '' },
 })
 
@@ -507,6 +510,32 @@ describe('SettingsModal Codex model preferences', () => {
     expect(reasoningOptions?.querySelector('option[value="max"]')).not.toBeNull()
     expect(reasoningOptions?.querySelector('option[value="ultra"]')).not.toBeNull()
     expect(await screen.findAllByText(/--model gpt-5\.6-sol/)).toHaveLength(2)
+  })
+})
+
+describe('SettingsModal Pi model preferences', () => {
+  beforeEach(() => {
+    useSettingsMock.mockReset()
+    useSettingsMock.mockReturnValue(createDefaultUseSettingsValue())
+    useSessionsMock.mockReset()
+    useSessionsMock.mockReturnValue(createDefaultUseSessionsValue())
+    invokeMock.mockClear()
+    invokeMock.mockImplementation(baseInvokeImplementation)
+    requestDockBounceMock.mockReset()
+  })
+
+  it('suggests Pi thinking levels without unsupported values', async () => {
+    renderWithProviders(<SettingsModal open={true} onClose={() => {}} />)
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByRole('button', { name: 'Agent Configuration' }))
+    await user.click(await screen.findByRole('button', { name: 'Pi' }))
+
+    const reasoningOptions = document.querySelector<HTMLDataListElement>('#agent-reasoning-options-pi')
+
+    expect(reasoningOptions?.querySelector('option[value="off"]')).not.toBeNull()
+    expect(reasoningOptions?.querySelector('option[value="max"]')).not.toBeNull()
+    expect(reasoningOptions?.querySelector('option[value="ultra"]')).toBeNull()
   })
 })
 

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -242,6 +242,16 @@ const CODEX_REASONING_OPTIONS: AgentPreferenceMetadataOption[] = [
     { value: 'ultra', label: 'Ultra' },
 ]
 
+const PI_THINKING_OPTIONS: AgentPreferenceMetadataOption[] = [
+    { value: 'off', label: 'Off' },
+    { value: 'minimal', label: 'Minimal' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'Extra high' },
+    { value: 'max', label: 'Max' },
+]
+
 const AGENT_PREFERENCE_METADATA: Record<AgentType, AgentPreferenceMetadata> = {
     claude: {},
     copilot: {},
@@ -257,6 +267,10 @@ const AGENT_PREFERENCE_METADATA: Record<AgentType, AgentPreferenceMetadata> = {
     qwen: {},
     amp: {},
     kilo: {},
+    pi: {
+        reasoningOptions: PI_THINKING_OPTIONS,
+        reasoningPlaceholder: 'Select thinking level',
+    },
     terminal: {},
 }
 

--- a/src/components/shared/agentDefaults.ts
+++ b/src/components/shared/agentDefaults.ts
@@ -29,6 +29,8 @@ export const displayNameForAgent = (agent: AgentType) => {
             return 'Amp'
         case 'kilo':
             return 'Kilo Code'
+        case 'pi':
+            return 'Pi'
         case 'terminal':
             return 'Terminal Only'
         default:

--- a/src/components/sidebar/SessionCard.tsx
+++ b/src/components/sidebar/SessionCard.tsx
@@ -161,6 +161,7 @@ export const getAgentColorKey = (
     case "gemini":
       return "orange";
     case "droid":
+    case "pi":
       return "violet";
     case "codex":
       return "red";

--- a/src/hooks/useAgentBinaryDetection.ts
+++ b/src/hooks/useAgentBinaryDetection.ts
@@ -30,6 +30,7 @@ export type AgentType =
     | 'qwen'
     | 'amp'
     | 'kilo'
+    | 'pi'
     | 'terminal'
 
 // UI agent names to backend agent names mapping
@@ -42,7 +43,8 @@ const AGENT_TO_BINARY_MAPPING: Record<string, AgentType> = {
     'droid': 'droid',
     'qwen': 'qwen',
     'amp': 'amp',
-    'kilo': 'kilo'
+    'kilo': 'kilo',
+    'pi': 'pi'
 }
 
 export function mapAgentToBinary(agentName: string): AgentType {
@@ -63,7 +65,8 @@ const DEFAULT_CONFIGS: Record<string, AgentBinaryConfig> = {
     'droid': { agent_name: 'droid', custom_path: null, auto_detect: true, detected_binaries: [] },
     'qwen': { agent_name: 'qwen', custom_path: null, auto_detect: true, detected_binaries: [] },
     'amp': { agent_name: 'amp', custom_path: null, auto_detect: true, detected_binaries: [] },
-    'kilo': { agent_name: 'kilo', custom_path: null, auto_detect: true, detected_binaries: [] }
+    'kilo': { agent_name: 'kilo', custom_path: null, auto_detect: true, detected_binaries: [] },
+    'pi': { agent_name: 'pi', custom_path: null, auto_detect: true, detected_binaries: [] }
 }
 
 // Cache for binary configs to avoid repeated backend calls

--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -40,6 +40,7 @@ describe('useSettings', () => {
         qwen: [{ key: 'PROJECT_ID', value: 'test-id' }],
         amp: [{ key: 'AMP_API_KEY', value: 'amp-key' }],
         kilo: [{ key: 'KILO_KEY', value: 'kilo-key' }],
+        pi: [{ key: 'PI_CODING_AGENT_DIR', value: '/tmp/pi-agent' }],
         terminal: []
       }
 
@@ -53,6 +54,7 @@ describe('useSettings', () => {
         qwen: '--project test',
         amp: '--mode free',
         kilo: '--mode architect',
+        pi: '--model openai-codex/gpt-5.6-terra',
         terminal: ''
       }
 
@@ -66,6 +68,7 @@ describe('useSettings', () => {
         qwen: { model: '', reasoningEffort: '' },
         amp: { model: '', reasoningEffort: '' },
         kilo: { model: '', reasoningEffort: '' },
+        pi: { model: 'openai-codex/gpt-5.6-terra', reasoningEffort: '' },
         terminal: { model: '', reasoningEffort: '' },
       }
 
@@ -129,6 +132,21 @@ describe('useSettings', () => {
         agentType: 'kilo',
         cliArgs: '--mode architect'
       })
+      expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetAgentEnvVars, {
+        agentType: 'pi',
+        envVars: { PI_CODING_AGENT_DIR: '/tmp/pi-agent' }
+      })
+      expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetAgentCliArgs, {
+        agentType: 'pi',
+        cliArgs: '--model openai-codex/gpt-5.6-terra'
+      })
+      expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetAgentPreferences, {
+        agentType: 'pi',
+        preferences: {
+          model: 'openai-codex/gpt-5.6-terra',
+          reasoning_effort: null,
+        },
+      })
       expect(mockInvoke).toHaveBeenCalledWith(TauriCommands.SetAgentPreferences, {
         agentType: 'codex',
         preferences: {
@@ -150,7 +168,7 @@ describe('useSettings', () => {
           reasoning_effort: null,
         },
       })
-      expect(mockInvoke).toHaveBeenCalledTimes(30)
+      expect(mockInvoke).toHaveBeenCalledTimes(33)
     })
 
     it('filters out empty environment variable keys', async () => {
@@ -170,6 +188,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       }
 
@@ -183,6 +202,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       }
 
@@ -196,6 +216,7 @@ describe('useSettings', () => {
         qwen: { model: '', reasoningEffort: '' },
         amp: { model: '', reasoningEffort: '' },
         kilo: { model: '', reasoningEffort: '' },
+        pi: { model: '', reasoningEffort: '' },
         terminal: { model: '', reasoningEffort: '' },
       }
 
@@ -372,6 +393,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       }
 
@@ -385,6 +407,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       }
 
@@ -398,6 +421,7 @@ describe('useSettings', () => {
         qwen: { model: '', reasoningEffort: '' },
         amp: { model: '', reasoningEffort: '' },
         kilo: { model: '', reasoningEffort: '' },
+        pi: { model: '', reasoningEffort: '' },
         terminal: { model: '', reasoningEffort: '' },
       }
 
@@ -468,6 +492,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       }
 
@@ -481,6 +506,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       }
 
@@ -494,6 +520,7 @@ describe('useSettings', () => {
         qwen: { model: '', reasoningEffort: '' },
         amp: { model: '', reasoningEffort: '' },
         kilo: { model: '', reasoningEffort: '' },
+        pi: { model: '', reasoningEffort: '' },
         terminal: { model: '', reasoningEffort: '' },
       }
 
@@ -559,6 +586,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       }
 
@@ -572,6 +600,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       }
 
@@ -585,6 +614,7 @@ describe('useSettings', () => {
         qwen: { model: '', reasoningEffort: '' },
         amp: { model: '', reasoningEffort: '' },
         kilo: { model: '', reasoningEffort: '' },
+        pi: { model: '', reasoningEffort: '' },
         terminal: { model: '', reasoningEffort: '' },
       }
 
@@ -718,6 +748,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       })
       expect(result.current.loading).toBe(false)
@@ -742,6 +773,7 @@ describe('useSettings', () => {
         qwen: [],
         amp: [],
         kilo: [],
+        pi: [],
         terminal: []
       })
     })
@@ -779,6 +811,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       })
     })
@@ -802,6 +835,7 @@ describe('useSettings', () => {
         qwen: '',
         amp: '',
         kilo: '',
+        pi: '',
         terminal: ''
       })
     })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -653,7 +653,7 @@
     "issueSelectHint": "Select an issue to pull its description and comments into the agent prompt.",
     "prSelectHint": "Select a pull request to pull its description and comments into the agent prompt. The session will start on the PR branch.",
     "enterSpecContent": "Enter spec content in markdown...",
-    "describeAgent": "Describe the agent for the Claude session",
+    "describeAgent": "Describe the task for this agent",
     "unifiedSearch": {
       "title": "Search",
       "branchesTab": "Branches",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -653,7 +653,7 @@
     "issueSelectHint": "选择一个议题以将其描述和评论拉入代理提示词。",
     "prSelectHint": "选择一个拉取请求以将其描述和评论拉入代理提示词。会话将在 PR 分支上启动。",
     "enterSpecContent": "输入规格内容（Markdown 格式）...",
-    "describeAgent": "描述 Claude 会话的代理任务",
+    "describeAgent": "描述此代理的任务",
     "unifiedSearch": {
       "title": "搜索",
       "branchesTab": "分支",

--- a/src/types/session.test.ts
+++ b/src/types/session.test.ts
@@ -13,6 +13,7 @@ describe('session agent constants', () => {
       'qwen',
       'amp',
       'kilo',
+      'pi',
       'terminal',
     ])
   })
@@ -29,5 +30,11 @@ describe('session agent constants', () => {
     expect(Object.keys(AGENT_SUPPORTS_SKIP_PERMISSIONS)).toEqual(AGENT_TYPES)
     expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.copilot).toBe(true)
     expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.kilo).toBe(false)
+    expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.pi).toBe(true)
+  })
+
+  it('treats Pi as a TUI-based agent', async () => {
+    const { isTuiAgent } = await import('./session')
+    expect(isTuiAgent('pi')).toBe(true)
   })
 })

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -8,11 +8,12 @@ export const AGENT_TYPES = [
     'qwen',
     'amp',
     'kilo',
+    'pi',
     'terminal'
 ] as const
 export type AgentType = (typeof AGENT_TYPES)[number]
 
-export const TUI_BASED_AGENTS: readonly AgentType[] = ['kilo', 'claude', 'opencode'] as const
+export const TUI_BASED_AGENTS: readonly AgentType[] = ['kilo', 'claude', 'opencode', 'pi'] as const
 
 export function isTuiAgent(agentType: string | null | undefined): boolean {
     if (!agentType) return false
@@ -29,6 +30,7 @@ export const AGENT_SUPPORTS_SKIP_PERMISSIONS: Record<AgentType, boolean> = {
     qwen: true,
     amp: true,
     kilo: false,
+    pi: true,
     terminal: false
 }
 

--- a/src/utils/agentColors.ts
+++ b/src/utils/agentColors.ts
@@ -9,6 +9,7 @@ export const getAgentColorKey = (
         case 'gemini':
             return 'orange'
         case 'droid':
+        case 'pi':
             return 'violet'
         case 'codex':
             return 'red'


### PR DESCRIPTION
## Summary
- add Pi as a first-class agent across backend, settings, and UI
- support initial prompts, approval mode, models, thinking levels, and exact persisted-session resumption
- extend the isolated macOS self-testing harness to use the real host Pi installation with private credential cleanup
- document Pi setup and session behavior

## Verification
- `CARGO_INCREMENTAL=0 just test`
  - 2,011 frontend tests passed (1 skipped)
  - 66 MCP tests passed
  - 1,171 Rust tests passed
  - lint, Clippy, dependency checks, and Rust build passed
- native macOS CUA with Pi 0.80.7
  - automatic initial prompt delivery confirmed
  - configured model and thinking level confirmed
  - persisted-session resume returned the expected context sentinel
  - full app relaunch restored the same Pi UUID and history without creating a second JSONL session
  - isolated credentials removed on shutdown