### PR TITLE
Remove the permission toggle for Pi

### DIFF
--- a/codex-skills/schaltwerk-macos-cua/SKILL.md
+++ b/codex-skills/schaltwerk-macos-cua/SKILL.md
@@ -58,11 +58,10 @@ No Codex project-trust prompt should appear. Treat one as a harness failure: sto
 the run, prepare fresh state, and inspect
 `logs/cua/macos-runtime/codex-home/config.toml` before continuing.
 
-For the real-Pi flow, select Pi, select **Skip permissions** so project-local Pi
-resources are approved inside the disposable repository, and use a unique prompt
-and output file just like the Codex smoke flow. Confirm the prompt starts
-automatically, the file appears in Changes, and restarting the terminal resumes the
-same Pi session without replaying the initial prompt.
+For the real-Pi flow, select Pi and use a unique prompt and output file just like
+the Codex smoke flow. Pi does not expose Schaltwerk's permission toggle. Confirm
+the prompt starts automatically, the file appears in Changes, and restarting the
+terminal resumes the same Pi session without replaying the initial prompt.
 
 ## Verify
 

--- a/docs-site/guides/agent-setup.mdx
+++ b/docs-site/guides/agent-setup.mdx
@@ -192,9 +192,11 @@ curl -fsSL https://pi.dev/install.sh | sh
 pi
 ```
 
-Schaltwerk passes the initial task directly to Pi, adds `--approve` when **Skip permissions** is
-enabled, and resumes the newest Pi session associated with the worktree. Pi's **Model** preference
-maps to `--model`; use the full `provider/model-id` value shown by `pi --list-models`.
+Schaltwerk passes the initial task directly to Pi and resumes the newest Pi session associated with
+the worktree. Pi does not use Schaltwerk's permission toggle: its similarly named `--approve` option
+trusts project-local Pi resources rather than bypassing tool confirmations. Add `--approve` under
+Pi's **CLI Arguments** only when you explicitly trust those resources. Pi's **Model** preference maps
+to `--model`; use the full `provider/model-id` value shown by `pi --list-models`.
 
 Pi stores sessions below `~/.pi/agent/sessions` by default. If you set `PI_CODING_AGENT_DIR` or
 `PI_CODING_AGENT_SESSION_DIR` in Pi's agent environment, Schaltwerk uses the same location for

--- a/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
+++ b/src-tauri/src/commands/schaltwerk_core/agent_ctx.rs
@@ -203,7 +203,6 @@ fn extract_pi_prompt_if_present(args: &mut Vec<String>) -> Option<String> {
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
-            "--approve" => index += 1,
             "--session" => index += 2,
             argument if argument.starts_with("--session=") => index += 1,
             _ if index + 1 == args.len() => return Some(args.remove(index)),
@@ -537,7 +536,7 @@ mod tests {
 
         let args = build_final_args(
             &AgentKind::Pi,
-            vec!["--approve".into(), "inspect the repository".into()],
+            vec!["inspect the repository".into()],
             "--no-extensions",
             &prefs,
         );
@@ -545,7 +544,6 @@ mod tests {
         assert_eq!(
             args,
             vec![
-                "--approve",
                 "--no-extensions",
                 "--model",
                 "openai-codex/gpt-5.6-terra",

--- a/src-tauri/src/domains/agents/pi.rs
+++ b/src-tauri/src/domains/agents/pi.rs
@@ -123,7 +123,7 @@ pub fn build_pi_command_with_config(
     worktree_path: &Path,
     session_id: Option<&str>,
     initial_prompt: Option<&str>,
-    skip_permissions: bool,
+    _skip_permissions: bool,
     config: Option<&PiConfig>,
 ) -> String {
     let binary = config
@@ -138,10 +138,6 @@ pub fn build_pi_command_with_config(
     if let Some(id) = session_id.map(str::trim).filter(|value| !value.is_empty()) {
         command.push_str(" --session ");
         command.push_str(&format_binary_invocation(id));
-    }
-
-    if skip_permissions {
-        command.push_str(" --approve");
     }
 
     if let Some(prompt) = initial_prompt.filter(|value| !value.trim().is_empty()) {
@@ -165,7 +161,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn builds_new_session_with_initial_prompt_and_approval() {
+    fn ignores_generic_skip_permissions_when_building_a_new_session() {
         let config = PiConfig {
             binary_path: Some("pi".to_string()),
         };
@@ -179,7 +175,7 @@ mod tests {
 
         assert_eq!(
             command,
-            r#"cd /path/to/worktree && pi --approve "implement feature X""#
+            r#"cd /path/to/worktree && pi "implement feature X""#
         );
     }
 

--- a/src-tauri/src/domains/agents/unified.rs
+++ b/src-tauri/src/domains/agents/unified.rs
@@ -604,10 +604,7 @@ mod tests {
                 binary_override: Some("pi"),
                 manifest,
             });
-            assert_eq!(
-                fresh.shell_command,
-                r#"cd /test/path && pi --approve "test prompt""#
-            );
+            assert_eq!(fresh.shell_command, r#"cd /test/path && pi "test prompt""#);
 
             let resumed = adapter.build_launch_spec(AgentLaunchContext {
                 worktree_path: Path::new("/test/path"),

--- a/src/components/inputs/ModelSelector.test.tsx
+++ b/src/components/inputs/ModelSelector.test.tsx
@@ -293,6 +293,13 @@ describe('ModelSelector', () => {
     expect(screen.queryByRole('button', { name: /Require permissions/i })).not.toBeInTheDocument()
   })
 
+  test('hides permission toggle for Pi', () => {
+    setup({ initial: 'pi', skipPermissions: false, onSkipPermissionsChange: vi.fn() })
+
+    expect(screen.queryByRole('button', { name: /Skip permissions/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Require permissions/i })).not.toBeInTheDocument()
+  })
+
   test('updates toggle visibility when selecting unsupported agent', async () => {
     const onSkipPermissionsChange = vi.fn()
     setup({ skipPermissions: false, onSkipPermissionsChange })

--- a/src/types/session.test.ts
+++ b/src/types/session.test.ts
@@ -30,7 +30,7 @@ describe('session agent constants', () => {
     expect(Object.keys(AGENT_SUPPORTS_SKIP_PERMISSIONS)).toEqual(AGENT_TYPES)
     expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.copilot).toBe(true)
     expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.kilo).toBe(false)
-    expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.pi).toBe(true)
+    expect(AGENT_SUPPORTS_SKIP_PERMISSIONS.pi).toBe(false)
   })
 
   it('treats Pi as a TUI-based agent', async () => {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -30,7 +30,7 @@ export const AGENT_SUPPORTS_SKIP_PERMISSIONS: Record<AgentType, boolean> = {
     qwen: true,
     amp: true,
     kilo: false,
-    pi: true,
+    pi: false,
     terminal: false
 }
 


### PR DESCRIPTION
## Summary
- hide Schaltwerk's permission toggle for Pi
- stop mapping the generic skip-permissions value to Pi's unrelated --approve option
- document explicit Pi project-resource trust and update the isolated macOS harness workflow

## Verification
- just test
- focused frontend tests: 24 passed
- focused Rust Pi tests: 61 passed
- isolated macOS release harness launched with real Pi 0.80.7 and cleaned up successfully