### PR TITLE
ci: accelerate validation pipeline without test sharding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,23 @@ jobs:
             workflows:
               - '.github/workflows/**'
 
-  lint-typescript:
-    name: TypeScript Lint & Format
+  typescript-checks:
+    name: TypeScript ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: changed
     if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ESLint
+            command: lint
+          - name: Type Check
+            command: lint:ts
+          - name: MCP Lint
+            command: lint:mcp
+          - name: Knip
+            command: deps:check
     env:
       SCHALTWERK_PM: bun
     steps:
@@ -86,18 +98,18 @@ jobs:
             cd mcp-server && node ../scripts/package-manager.mjs install --frozen-lockfile && cd ..
           fi
 
-      - name: Run TypeScript lints
-        run: |
-          node scripts/package-manager.mjs run lint
-          node scripts/package-manager.mjs run lint:ts
-          node scripts/package-manager.mjs run lint:mcp
-          node scripts/package-manager.mjs run deps:check
+      - name: Run ${{ matrix.name }}
+        run: node scripts/package-manager.mjs run ${{ matrix.command }}
 
   test-frontend:
-    name: Frontend Tests
+    name: Frontend Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: changed
     if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
     env:
       SCHALTWERK_PM: bun
     steps:
@@ -131,16 +143,28 @@ jobs:
             cd mcp-server && node ../scripts/package-manager.mjs install --frozen-lockfile && cd ..
           fi
 
-      - name: Run frontend tests
+      - name: Run frontend test shard ${{ matrix.shard }}
+        run: node scripts/package-manager.mjs run test:frontend -- --shard=${{ matrix.shard }}
+
+      - name: Run MCP and build-script tests
+        if: matrix.shard == '1/3'
         run: |
-          node scripts/package-manager.mjs run test:frontend
           node scripts/package-manager.mjs run test:mcp
+          node scripts/package-manager.mjs run test:build-scripts
 
   rust-checks:
-    name: Rust Checks
+    name: Rust ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: changed
     if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Lint
+            kind: lint
+          - name: Tests
+            kind: tests
     env:
       # Override target-cpu=native from .cargo/config.toml - CI runners have varying CPU features
       # which can cause SIGILL crashes with native CPU targeting
@@ -195,25 +219,35 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: src-tauri/target/
-          key: cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: cargo-target-${{ runner.os }}-${{ matrix.kind }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            cargo-target-${{ runner.os }}-${{ matrix.kind }}-
+            cargo-target-${{ runner.os }}-
 
       - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612
+        if: matrix.kind == 'lint'
         with:
           tool: cargo-shear
           version: 1.5.2
 
       - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612
+        if: matrix.kind == 'tests'
         with:
           tool: nextest
           version: 0.9.108
 
-      - name: Run Rust checks
+      - name: Run Rust lint
+        if: matrix.kind == 'lint'
         run: |
           cd src-tauri
           cargo clippy --all-features -- -D warnings
           cargo shear
+
+      - name: Run Rust tests
+        if: matrix.kind == 'tests'
+        run: |
+          cd src-tauri
           cargo nextest run --profile ci --all-features --status-level fail --failure-output immediate
-          cargo build
 
       - name: Save cargo home cache
         if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true' && !env.ACT
@@ -233,20 +267,20 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: src-tauri/target/
-          key: cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: cargo-target-${{ runner.os }}-${{ matrix.kind }}-${{ hashFiles('src-tauri/Cargo.lock') }}
 
   results:
     name: CI Results (required)
-    needs: [changed, lint-typescript, test-frontend, rust-checks]
+    needs: [changed, typescript-checks, test-frontend, rust-checks]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
         shell: bash
         run: |
-          echo "lint-typescript: ${{ needs.lint-typescript.result }}"
-          echo "test-frontend  : ${{ needs.test-frontend.result }}"
-          echo "rust-checks    : ${{ needs.rust-checks.result }}"
+          echo "typescript-checks: ${{ needs.typescript-checks.result }}"
+          echo "test-frontend    : ${{ needs.test-frontend.result }}"
+          echo "rust-checks      : ${{ needs.rust-checks.result }}"
           
           # If no relevant changes, succeed
           if [[ '${{ needs.changed.outputs.schaltwerk }}' != 'true' && '${{ needs.changed.outputs.workflows }}' != 'true' && '${{ github.event_name }}' != 'push' ]]; then
@@ -255,7 +289,7 @@ jobs:
           fi
           
           # All jobs must succeed
-          [[ '${{ needs.lint-typescript.result }}' == 'success' ]] || { echo 'lint-typescript failed'; exit 1; }
+          [[ '${{ needs.typescript-checks.result }}' == 'success' ]] || { echo 'typescript-checks failed'; exit 1; }
           [[ '${{ needs.test-frontend.result }}' == 'success' ]] || { echo 'test-frontend failed'; exit 1; }
           [[ '${{ needs.rust-checks.result }}' == 'success' ]] || { echo 'rust-checks failed'; exit 1; }
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -104,7 +104,7 @@ jobs:
           fi
 
       - name: Run frontend tests
-        run: node scripts/package-manager.mjs run test:frontend -- --maxWorkers=12
+        run: node scripts/package-manager.mjs run test:frontend
 
       - name: Run MCP and build-script tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,43 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changed:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      schaltwerk: ${{ steps.filter.outputs.schaltwerk }}
-      workflows: ${{ steps.filter.outputs.workflows }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - id: filter
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            schaltwerk:
-              - 'src/**'
-              - 'src-tauri/**'
-              - 'mcp-server/**'
-              - 'scripts/**'
-              - 'package.json'
-              - 'bun.lock'
-              - 'justfile'
-              - 'tsconfig.json'
-              - 'knip.json'
-              - 'vitest.config.ts'
-              - 'vite.config.ts'
-              - 'postcss.config.js'
-              - 'tailwind.config.js'
-              - 'eslint.config.js'
-              - 'eslint-rules/**'
-            workflows:
-              - '.github/workflows/**'
-
   typescript-checks:
     name: TypeScript ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: changed
-    if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,14 +68,8 @@ jobs:
         run: node scripts/package-manager.mjs run ${{ matrix.command }}
 
   test-frontend:
-    name: Frontend Tests (${{ matrix.shard }})
+    name: Frontend Tests
     runs-on: ubuntu-latest
-    needs: changed
-    if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: ['1/3', '2/3', '3/3']
     env:
       SCHALTWERK_PM: bun
     steps:
@@ -143,11 +103,10 @@ jobs:
             cd mcp-server && node ../scripts/package-manager.mjs install --frozen-lockfile && cd ..
           fi
 
-      - name: Run frontend test shard ${{ matrix.shard }}
-        run: node scripts/package-manager.mjs run test:frontend -- --shard=${{ matrix.shard }}
+      - name: Run frontend tests
+        run: node scripts/package-manager.mjs run test:frontend -- --maxWorkers=12
 
       - name: Run MCP and build-script tests
-        if: matrix.shard == '1/3'
         run: |
           node scripts/package-manager.mjs run test:mcp
           node scripts/package-manager.mjs run test:build-scripts
@@ -155,8 +114,6 @@ jobs:
   rust-checks:
     name: Rust ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: changed
-    if: ${{ needs.changed.outputs.schaltwerk == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
     strategy:
       fail-fast: false
       matrix:
@@ -176,15 +133,15 @@ jobs:
         uses: actions/cache@v6
         id: apt-cache
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/test.yml') }}
+          path: /var/cache/apt/archives/*.deb
+          key: ${{ runner.os }}-${{ runner.arch }}-tauri-apt-v1
           restore-keys: |
-            ${{ runner.os }}-apt-
+            ${{ runner.os }}-${{ runner.arch }}-tauri-apt-
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf mold clang sccache
+          sudo apt-get -o APT::Keep-Downloaded-Packages=true install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf mold clang sccache
 
       - name: Setup sccache cache
         uses: Mozilla-Actions/sccache-action@v0.0.9
@@ -247,7 +204,7 @@ jobs:
         if: matrix.kind == 'tests'
         run: |
           cd src-tauri
-          cargo nextest run --profile ci --all-features --status-level fail --failure-output immediate
+          cargo nextest run --profile ci --all-features --test-threads 12 --status-level fail --failure-output immediate
 
       - name: Save cargo home cache
         if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true' && !env.ACT
@@ -271,7 +228,7 @@ jobs:
 
   results:
     name: CI Results (required)
-    needs: [changed, typescript-checks, test-frontend, rust-checks]
+    needs: [typescript-checks, test-frontend, rust-checks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -281,13 +238,7 @@ jobs:
           echo "typescript-checks: ${{ needs.typescript-checks.result }}"
           echo "test-frontend    : ${{ needs.test-frontend.result }}"
           echo "rust-checks      : ${{ needs.rust-checks.result }}"
-          
-          # If no relevant changes, succeed
-          if [[ '${{ needs.changed.outputs.schaltwerk }}' != 'true' && '${{ needs.changed.outputs.workflows }}' != 'true' && '${{ github.event_name }}' != 'push' ]]; then
-            echo 'No relevant changes -> CI passed.'
-            exit 0
-          fi
-          
+
           # All jobs must succeed
           [[ '${{ needs.typescript-checks.result }}' == 'success' ]] || { echo 'typescript-checks failed'; exit 1; }
           [[ '${{ needs.test-frontend.result }}' == 'success' ]] || { echo 'test-frontend failed'; exit 1; }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Prepare apt cache
+        run: sudo chown "$USER" /var/cache/apt/archives
+
       - name: Cache apt packages
         uses: actions/cache@v6
         id: apt-cache

--- a/src/test/setup-node.ts
+++ b/src/test/setup-node.ts
@@ -1,0 +1,33 @@
+import { beforeEach } from 'vitest'
+
+const createMemoryStorage = () => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => {
+      store.clear()
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+for (const prop of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, prop, {
+    configurable: true,
+    value: createMemoryStorage(),
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,66 @@
 import { defineConfig } from 'vite'
 import path from 'path'
 
+const domTestFiles = [
+  'src/**/*.test.tsx',
+  'src/common/terminalSizeCache.test.ts',
+  'src/components/diff/sidebarScroll.test.ts',
+  'src/components/inputs/dropdownGeometry.test.ts',
+  'src/components/terminal/TerminalResizeCoordinator.test.ts',
+  'src/components/terminal/terminalKeybindings.test.ts',
+  'src/dev/registerDevErrorListeners.test.ts',
+  'src/hooks/__tests__/useTerminalGpu.test.ts',
+  'src/hooks/useAgentTabs.test.ts',
+  'src/hooks/useBranchSearch.test.ts',
+  'src/hooks/useClaudeSession.test.ts',
+  'src/hooks/useDiffHover.test.ts',
+  'src/hooks/useLineSelection.test.ts',
+  'src/hooks/useOnboarding.test.ts',
+  'src/hooks/usePermissions.test.ts',
+  'src/hooks/useProjectFileIndex.test.ts',
+  'src/hooks/useReviewComments.test.ts',
+  'src/hooks/useSelectionPreserver.test.ts',
+  'src/hooks/useSessionManagement.test.ts',
+  'src/hooks/useSessionPrefill.test.ts',
+  'src/hooks/useSettings.test.ts',
+  'src/hooks/useSetupScriptApproval.test.ts',
+  'src/hooks/useSpecMode.test.ts',
+  'src/hooks/useStreamingDecoder.test.ts',
+  'src/hooks/useTerminalTabs.test.ts',
+  'src/hooks/useUpdateSessionFromParent.test.ts',
+  'src/keyboardShortcuts/matcher.test.ts',
+  'src/store/atoms/fontSize.test.ts',
+  'src/store/atoms/language.test.ts',
+  'src/store/atoms/layout.test.ts',
+  'src/store/atoms/project.test.ts',
+  'src/store/atoms/selection.test.ts',
+  'src/store/atoms/terminal.test.ts',
+  'src/store/atoms/theme.test.ts',
+  'src/utils/__tests__/splitDragCoordinator.test.ts',
+  'src/utils/normalizeCliText.test.ts',
+  'src/terminal/gpu/webglCapability.test.ts',
+  'src/terminal/gpu/webglRenderer.test.ts',
+  'src/terminal/registry/terminalRegistry.test.ts',
+  'src/terminal/xterm/XtermTerminal.test.ts',
+]
+
+const nodeTestFiles = [
+  'src/**/*.test.ts',
+  'scripts/cua/**/*.test.js',
+]
+
+const excludedFiles = [
+  'node_modules/**',
+  'vscode/**',
+  '.schaltwerk/**',
+  'dist/**',
+  '**/*.performance.test.*',
+  '**/*.bench.test.*',
+]
+
 export default defineConfig({
   test: {
-    environment: 'happy-dom',
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
     server: {
       deps: {
         inline: ['@pierre/diffs', 'lru_map'],
@@ -19,18 +74,27 @@ export default defineConfig({
         maxThreads: 4,
       },
     },
-    include: [
-      'src/**/*.test.ts',
-      'src/**/*.test.tsx',
-      'scripts/cua/**/*.test.js'
-    ],
-    exclude: [
-      'node_modules/**',
-      'vscode/**',
-      '.schaltwerk/**',
-      'dist/**',
-      '**/*.performance.test.*',
-      '**/*.bench.test.*'
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'node',
+          environment: 'node',
+          setupFiles: ['./src/test/setup-node.ts'],
+          include: nodeTestFiles,
+          exclude: [...excludedFiles, ...domTestFiles],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'dom',
+          environment: 'happy-dom',
+          setupFiles: ['./src/test/setup.ts'],
+          include: domTestFiles,
+          exclude: excludedFiles,
+        },
+      },
     ],
     coverage: {
       reporter: ['text', 'json', 'json-summary', 'html'],


### PR DESCRIPTION
## Summary

- start substantive validation immediately instead of waiting for a change-detection job
- run independent TypeScript checks and Rust lint/tests in parallel
- keep frontend tests in one complete, unsharded Vitest invocation
- use lightweight Node setup for pure TypeScript tests and happy-dom only where the suite needs it
- use Node 22, dedicated Cargo caches, cached apt packages, and tuned nextest concurrency
- remove the redundant final `cargo build`; nextest already builds and links the application binary
- retain the build-output synchronizer regression test in CI

## Measured GitHub Actions improvement

Compared with successful `main` run [30195789329](https://github.com/2mawi2/schaltwerk/actions/runs/30195789329), the latest green PR run [30197350652](https://github.com/2mawi2/schaltwerk/actions/runs/30197350652) improved as follows:

| Critical path | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Required pipeline result | 172s | 106s | **38.4% faster** |
| TypeScript | 71s | 48s | **32.4% faster** |
| Frontend tests job | 117s | 97s | **17.1% faster** |
| Rust | 157s | 98s | **37.6% faster** |

The preceding green iteration completed the frontend job in 93s (20.5% faster), so the frontend result shows the normal runner variance. Its Vitest core improved from 95.95s on `main` to 73.05s in that run (23.9%).

No test sharding is used. The single frontend command runs all 244 files / 2,013 tests, and the Rust CI command runs all 1,164 platform-applicable tests.

## Verification

- `just test`
- repeated full, unsharded frontend runs
- workflow YAML parse
- `git diff --check`
